### PR TITLE
Hide order line numbers and add postcode fallback for invalid link

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -1,6 +1,9 @@
 /* ===== Basis / layout ===== */
 .rmh-ot{border:0;padding:0}
 .rmh-ot--error{border:1px solid #f5c2c7;background:#f8d7da;padding:12px;border-radius:8px;color:#842029}
+.rmh-ot__postcode-form{margin-top:8px}
+.rmh-ot__postcode-form input{margin-right:6px;padding:4px}
+.rmh-ot__postcode-form button{padding:4px 8px}
 .rmh-ot__items{display:flex;flex-direction:column;align-items:flex-start;}
 .rmh-ot__items h3{margin:10px 0;text-align:left!important;margin-left:0}
 .rmh-ot__grid{display:block!important}
@@ -14,16 +17,14 @@
 .rmh-ot__image{width:100%;height:auto;display:block}
 @media(max-width:1200px)and(min-width:901px){.rmh-ot__photo{max-width: 200px;}}
 .rmh-ot__title{font-size:1.8rem;font-weight:800;margin:0}
-.rmh-ot__sub{color:#E53935;font-weight:700;margin:.3rem 0 1rem}
 .rmh-ot__item-header{position:relative;margin-bottom:.5rem}
 .rmh-ot__badge-top{position:absolute;right:18px;top:18px} /* desktop/tablet */
 
-/* Mobiel: titel → orderregel → badge (gecentreerd onder elkaar) */
+/* Mobiel: titel → badge (gecentreerd onder elkaar) */
 @media(max-width:600px){
   .rmh-ot__item-header{display:flex;flex-direction:column;text-align:center}
   .rmh-ot__title{order:1;margin-bottom:2px!important;}
-  .rmh-ot__sub{order:2;margin-top:0!important;margin-bottom:4px!important;}
-  .rmh-ot__badge-top{order:3;position:static;display:inline-block;margin-top:4px;}
+  .rmh-ot__badge-top{order:2;position:static;display:inline-block;margin-top:4px;}
 }
 
 /* Status-badge kleuren (per product) */


### PR DESCRIPTION
## Summary
- Remove Print.com order line numbers from the order page and clean up related CSS
- Clarify the error shown when the URL token is missing or incorrect and allow postcode verification as a fallback
- Bump plugin version to 2.0.1

## Testing
- `php -l printcom-order-tracker.php`
- `php -l uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7f8357e80832cb1e100f63cfc8491