### PR TITLE
Add order lookup shortcode and remove page creation

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -4,6 +4,9 @@
 .rmh-ot__postcode-form{margin-top:8px}
 .rmh-ot__postcode-form input{margin-right:6px;padding:4px}
 .rmh-ot__postcode-form button{padding:4px 8px}
+.rmh-ot__lookup-form{margin-top:8px}
+.rmh-ot__lookup-form input{margin-right:6px;padding:4px}
+.rmh-ot__lookup-form button{padding:4px 8px}
 .rmh-ot__items{display:flex;flex-direction:column;align-items:flex-start;}
 .rmh-ot__items h3{margin:10px 0;text-align:left!important;margin-left:0}
 .rmh-ot__grid{display:block!important}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -26,6 +26,7 @@ class Printcom_Order_Tracker {
         add_action('save_post_page', [$this, 'enforce_divi_layout_on_save'], 20, 3);
 
         add_shortcode('print_order_status', [$this, 'render_order_shortcode']);
+        add_shortcode('print_order_lookup', [$this, 'render_lookup_shortcode']);
 
         add_action('add_meta_boxes', [$this, 'add_metaboxes']);
         add_action('save_post',       [$this, 'save_metaboxes']);
@@ -222,16 +223,6 @@ class Printcom_Order_Tracker {
         $parent_id = 0;
         $parent = get_page_by_path('bestellingen');
         if ($parent) { $parent_id = (int)$parent->ID; }
-        else {
-            $parent_id = wp_insert_post([
-                'post_title' => 'Bestellingen',
-                'post_name'  => 'bestellingen',
-                'post_status'=> 'publish',
-                'post_type'  => 'page',
-                'post_author'=> get_current_user_id(),
-            ]);
-            if (is_wp_error($parent_id)) $parent_id = 0; else $parent_id = (int)$parent_id;
-        }
 
         $token = $mappings[$ownOrder]['token'] ?? wp_generate_password(20,false,false);
 
@@ -363,6 +354,37 @@ class Printcom_Order_Tracker {
     }
 
     /* ===== Shortcode ===== */
+
+    public function render_lookup_shortcode() {
+        $error = '';
+        if (!empty($_POST['rmh_ot_lookup_order']) && !empty($_POST['rmh_ot_lookup_postcode'])) {
+            $order = sanitize_text_field(wp_unslash($_POST['rmh_ot_lookup_order']));
+            $maps  = get_option(self::OPT_MAPPINGS, []);
+            if (!empty($maps[$order])) {
+                $map   = $maps[$order];
+                $data  = $this->api_get_order($map['print_order']);
+                if (!is_wp_error($data)) {
+                    $addr  = $this->extract_primary_shipping_address($data);
+                    $postal= preg_replace('/\s+/','',strtoupper($addr['postcode'] ?? ''));
+                    $input = preg_replace('/\s+/','',strtoupper(sanitize_text_field(wp_unslash($_POST['rmh_ot_lookup_postcode']))));
+                    if ($input === $postal) {
+                        $url = add_query_arg('token', rawurlencode($map['token']), get_permalink((int)$map['page_id']));
+                        wp_safe_redirect($url);
+                        exit;
+                    }
+                }
+            }
+            $error = '<div class="rmh-ot rmh-ot--error">Onbekend ordernummer of postcode.</div>';
+        }
+        $form  = '<form class="rmh-ot__lookup-form" method="post">';
+        $form .= '<label for="rmh_ot_lookup_order">Ordernummer (bijv. RMH-12345)</label> ';
+        $form .= '<input type="text" id="rmh_ot_lookup_order" name="rmh_ot_lookup_order" placeholder="RMH-[nummer]" required/> ';
+        $form .= '<label for="rmh_ot_lookup_postcode">Postcode (bijv. 1234AB)</label> ';
+        $form .= '<input type="text" id="rmh_ot_lookup_postcode" name="rmh_ot_lookup_postcode" placeholder="1234AB" required/> ';
+        $form .= '<button type="submit">Zoek bestelling</button>';
+        $form .= '</form>';
+        return $error . $form;
+    }
 
     public function render_order_shortcode($atts=[]) {
         $atts = shortcode_atts(['order'=>''], $atts, 'print_order_status');

--- a/readme.md
+++ b/readme.md
@@ -8,14 +8,16 @@ Tokens worden automatisch vernieuwd. Ontworpen om goed samen te werken met **Div
 1. Upload de plugin of installeer via [WPPusher](https://wppusher.com).
 2. Activeer de plugin via **Plugins → Geïnstalleerde plugins**.
 3. Ga naar **Instellingen → Print.com Orders** en vul je API-gegevens in.
-4. Voeg een ordernummer toe via het menu **Print.com Orders**.  
+4. Voeg een ordernummer toe via het menu **Print.com Orders**.
    De plugin maakt automatisch een pagina aan met de shortcode:  [print_order_status order=“123456789”]
+5. Plaats de shortcode [print_order_lookup] om klanten te laten zoeken op ordernummer en postcode.
 
 ## Features
 - Automatisch pagina’s aanmaken/bijwerken per ordernummer  
-- Orderstatus, producten en Track & Trace links tonen  
-- Cache instelbaar (default 30 minuten)  
-- Ondersteuning voor eigen afbeelding per orderpagina  
+- Orderstatus, producten en Track & Trace links tonen
+- Zoekformulier op ordernummer + postcode via shortcode [print_order_lookup]
+- Cache instelbaar (default 30 minuten)
+- Ondersteuning voor eigen afbeelding per orderpagina
 - Tokens worden automatisch vernieuwd  
 
 ## Vereisten


### PR DESCRIPTION
## Summary
- add `[print_order_lookup]` shortcode allowing search by order number and postcode
- redirect to existing order page with token on successful lookup
- remove automatic creation of the `Bestellingen` page
- document new shortcode and basic styling

## Testing
- `php -l printcom-order-tracker.php`

------
https://chatgpt.com/codex/tasks/task_e_68c804a90190832c80479328a01ae147