### PR TITLE
Improve order lookup form styling and validation

### DIFF
--- a/assets/css/order-lookup.css
+++ b/assets/css/order-lookup.css
@@ -1,0 +1,106 @@
+.rmh-order-lookup {
+    max-width: 640px;
+    margin: 20px auto;
+    background: #fff;
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+}
+
+.rmh-order-lookup .rmh-ol__title {
+    margin-top: 0;
+    text-align: center;
+    font-weight: 700;
+}
+
+.rmh-order-lookup .rmh-ol__feedback {
+    margin-bottom: 16px;
+    display: none;
+    border-radius: 12px;
+    padding: 12px;
+}
+
+.rmh-order-lookup .rmh-ol__feedback--error {
+    display: block;
+    border: 1px solid #f5c2c7;
+    background: #f8d7da;
+    color: #842029;
+}
+
+.rmh-order-lookup .rmh-ol__feedback--ok {
+    display: block;
+    border: 1px solid #cce3d1;
+    background: #e9f7ef;
+    color: #255d37;
+}
+
+.rmh-order-lookup .rmh-ol__form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.rmh-order-lookup .rmh-ol__row {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+@media (min-width: 640px) {
+    .rmh-order-lookup .rmh-ol__row {
+        flex-direction: row;
+    }
+}
+
+.rmh-order-lookup .rmh-ol__field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.rmh-order-lookup .rmh-ol__label {
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.rmh-order-lookup .rmh-ol__input {
+    border: 1px solid rgba(0,0,0,.12);
+    border-radius: 12px;
+    padding: 12px 14px;
+}
+
+.rmh-order-lookup .rmh-ol__input::placeholder {
+    color: #9e9e9e;
+}
+
+.rmh-order-lookup .rmh-ol__input:focus {
+    outline: none;
+    border-color: #e53935;
+    box-shadow: 0 0 0 3px rgba(229,57,53,.2);
+}
+
+.rmh-order-lookup .rmh-ol__hint {
+    font-size: 12px;
+    color: #757575;
+    margin-top: 4px;
+}
+
+.rmh-order-lookup .rmh-ol__actions {
+    text-align: right;
+}
+
+.rmh-order-lookup .rmh-ol__btn {
+    background: #e53935;
+    color: #fff;
+    font-weight: 700;
+    padding: 12px 20px;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: filter .2s, box-shadow .2s;
+}
+
+.rmh-order-lookup .rmh-ol__btn:hover {
+    filter: brightness(1.1);
+    box-shadow: 0 2px 6px rgba(0,0,0,.2);
+}

--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -31,8 +31,8 @@
 /* Mobiel: titel → badge (gecentreerd onder elkaar) */
 @media(max-width:600px){
   .rmh-ot__item-header{display:flex;flex-direction:column;text-align:center}
-  .rmh-ot__title{order:1;margin-bottom:2px!important;}
-  .rmh-ot__badge-top{order:2;position:static;display:inline-block;margin-top:4px;}
+  .rmh-ot__badge-top{order:1;position:static;display:inline-block;margin-bottom:4px;}
+  .rmh-ot__title{order:2;margin-top:2px!important;}
 }
 
 /* Status-badge kleuren (per product) */


### PR DESCRIPTION
## Summary
- add accessible, responsive order lookup shortcode
- scope lookup CSS and load assets only when shortcode present
- show status badge above product title on mobile
- bump plugin version to 2.1.5

## Testing
- `php -l printcom-order-tracker.php`


------
https://chatgpt.com/codex/tasks/task_e_68c8205e9d30832cb8048d2e3ee08dec