### PR TITLE
Adjust lookup form spacing and label emphasis

### DIFF
--- a/assets/css/order-lookup.css
+++ b/assets/css/order-lookup.css
@@ -9,6 +9,7 @@
 
 .rmh-order-lookup .rmh-ol__title {
     margin-top: 0;
+    margin-bottom: 24px;
     text-align: center;
     font-weight: 700;
     font-size: 2rem;
@@ -50,6 +51,7 @@
 
 .rmh-order-lookup .rmh-ol__label {
     font-weight: 700;
+    font-size: 1.125rem;
     margin-bottom: 4px;
 }
 


### PR DESCRIPTION
## Summary
- add extra margin below the order lookup heading to create more space before the form fields
- increase the order and postcode label size to improve emphasis while keeping them bold

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c830dff4c4832cbf35684071b2cb90