### PR TITLE
Add dynamic order summary with aggregated status

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -1,6 +1,8 @@
 /* ===== Basis / layout ===== */
 .rmh-ot{border:0;padding:0}
 .rmh-ot--error{border:1px solid #f5c2c7;background:#f8d7da;padding:12px;border-radius:8px;color:#842029}
+.rmh-ot__summary{margin:12px auto 24px;text-align:center;font-size:1.125rem;font-weight:500;color:#4a4a4a;line-height:1.5;max-width:960px}
+.rmh-ot__summary-count,.rmh-ot__summary-status{font-weight:600}
 .rmh-ot__postcode-form{margin-top:8px}
 .rmh-ot__postcode-form input{margin-right:6px;padding:4px}
 .rmh-ot__postcode-form button{padding:4px 8px}


### PR DESCRIPTION
## Summary
- show a dynamic summary sentence above the order details that reports the product count and the aggregated order status
- reuse a shared status classification helper so both the summary and per-item badges interpret item states consistently
- style the summary text and bump the stylesheet version so the new presentation loads immediately

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68c8367124a8832c8af3ada486a3e19a