### PR TITLE
Center order tracker items container

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -12,7 +12,7 @@
 .rmh-ot__lookup-form .required{color:#E53935}
 .rmh-ot__lookup-form input{padding:10px;border:1px solid #ddd;border-radius:8px}
 .rmh-ot__lookup-form .btn{grid-column:1/-1;width:100%;font-weight:700}
-.rmh-ot__items{display:flex;flex-direction:column;}
+.rmh-ot__items{display:flex;flex-direction:column;width:100%;max-width:1200px;margin-left:auto;margin-right:auto;}
 .rmh-ot__items h3{margin:10px 0;text-align:center;margin-left:0}
 .rmh-ot__grid{display:block!important}
 .rmh-ot__items::after{content:"";display:block;clear:both}


### PR DESCRIPTION
## Summary
- center the order items container within the page layout
- cap the container width at 1200px while keeping it full-width on smaller screens

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68c83838ab20832c9b217ee70c93c22c