### PR TITLE
Allow logged-in users to bypass order token check

### DIFF
--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -421,10 +421,11 @@ class Printcom_Order_Tracker {
 
         $maps = get_option(self::OPT_MAPPINGS, []);
         if (empty($maps[$own])) return '<div class="rmh-ot rmh-ot--error">Onbekend ordernummer.</div>';
-        $map      = $maps[$own];
-        $token    = $map['token'] ?? '';
-        $orderNum = $map['print_order'];
-        $valid    = !empty($_GET['token']) && sanitize_text_field(wp_unslash($_GET['token'])) === $token;
+        $map            = $maps[$own];
+        $token          = $map['token'] ?? '';
+        $orderNum       = $map['print_order'];
+        $requestedToken = isset($_GET['token']) ? sanitize_text_field(wp_unslash($_GET['token'])) : '';
+        $valid          = is_user_logged_in() || ($requestedToken !== '' && $requestedToken === $token);
         $cache_key=self::TRANSIENT_PREFIX.md5($orderNum);
         $data=null;
 


### PR DESCRIPTION
## Summary
- allow logged-in users to view order tracking pages without needing a token
- retain the token requirement for guests by checking the request token when the visitor is not logged in

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68c8391ad95c832cbed9b7efabf3c52e