### PR TITLE
Add Invoice Ninja portal link integration

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -75,3 +75,9 @@
 .btn--track{background:#E53935;color:#fff;border-color:#B71C1C}
 .btn--track[aria-disabled="true"]{background:#ffcdd2;border-color:#ef9a9a;color:#B71C1C;cursor:not-allowed}
 
+/* Invoice Ninja CTA */
+.rmh-invoice-cta{margin:1rem 0;text-align:right}
+@media(max-width:900px){.rmh-invoice-cta{text-align:center}}
+.rmh-btn.rmh-btn-pay{display:inline-block;padding:.6rem 1rem;border-radius:.375rem;text-decoration:none;background-color:var(--rmh-btn-pay-bg,#0B63C4);color:#fff;border:1px solid var(--rmh-btn-pay-border,#0B63C4);font-weight:600;transition:background-color .2s ease,border-color .2s ease,color .2s ease}
+.rmh-btn.rmh-btn-pay:hover,.rmh-btn.rmh-btn-pay:focus{background-color:var(--rmh-btn-pay-bg-hover,#094f9c);border-color:var(--rmh-btn-pay-border-hover,#094f9c);color:#fff}
+

--- a/includes/class-rmh-invoice-ninja-client.php
+++ b/includes/class-rmh-invoice-ninja-client.php
@@ -1,0 +1,152 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class RMH_InvoiceNinja_Client {
+    /**
+     * Base URL for the Invoice Ninja instance (without trailing slash).
+     *
+     * @var string
+     */
+    private $base_url;
+
+    /**
+     * API token used for authenticating requests.
+     *
+     * @var string
+     */
+    private $api_token;
+
+    /**
+     * Cache lifetime for invitation links in seconds.
+     *
+     * @var int
+     */
+    private $cache_ttl;
+
+    /**
+     * Constructor.
+     *
+     * @param string $base_url      Invoice Ninja base URL.
+     * @param string $api_token     API token for Invoice Ninja v5.
+     * @param int    $cache_minutes Cache duration in minutes.
+     */
+    public function __construct( string $base_url, string $api_token, int $cache_minutes = 10 ) {
+        $this->base_url  = rtrim( $base_url, '/' );
+        $this->api_token = $api_token;
+        $this->cache_ttl = max( 0, absint( $cache_minutes ) ) * MINUTE_IN_SECONDS;
+    }
+
+    /**
+     * Retrieve the client portal link for a given invoice.
+     *
+     * @param mixed $invoice_id Invoice identifier as provided by Invoice Ninja.
+     * @return string|null
+     */
+    public function get_invoice_portal_link( $invoice_id ): ?string {
+        $invoice = is_scalar( $invoice_id ) ? trim( (string) $invoice_id ) : '';
+        if ( $invoice === '' ) {
+            return null;
+        }
+
+        $cache_key = 'rmh_in_invit_' . md5( $invoice );
+        if ( $this->cache_ttl > 0 ) {
+            $cached = get_transient( $cache_key );
+            if ( is_string( $cached ) && $cached !== '' ) {
+                return $cached;
+            }
+        }
+
+        $url  = $this->base_url . '/api/v1/invoices/' . rawurlencode( $invoice ) . '?include=invitations';
+        $args = [
+            'timeout' => 10,
+            'headers' => [
+                'X-API-Token'      => $this->api_token,
+                'X-Requested-With' => 'XMLHttpRequest',
+                'Accept'           => 'application/json',
+                'User-Agent'       => 'RMH-Order-Tracker (+WordPress)',
+            ],
+        ];
+
+        $response = wp_remote_get( $url, $args );
+        if ( is_wp_error( $response ) ) {
+            error_log( '[RMH Invoice Ninja] HTTP error for invoice ' . sanitize_text_field( $invoice ) . ': ' . $response->get_error_message() );
+            return null;
+        }
+
+        $status = wp_remote_retrieve_response_code( $response );
+        if ( $status < 200 || $status >= 300 ) {
+            error_log( '[RMH Invoice Ninja] Unexpected status ' . $status . ' for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+        if ( ! is_array( $data ) ) {
+            error_log( '[RMH Invoice Ninja] Invalid JSON response for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        $invitation = $this->extract_first_invitation( $data );
+        if ( ! $invitation ) {
+            error_log( '[RMH Invoice Ninja] No invitation found for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        $link = '';
+        if ( ! empty( $invitation['link'] ) ) {
+            $link = (string) $invitation['link'];
+        } elseif ( ! empty( $invitation['key'] ) ) {
+            $link = $this->base_url . '/client/invoice/' . rawurlencode( (string) $invitation['key'] );
+        }
+
+        $link = trim( $link );
+        if ( $link === '' ) {
+            error_log( '[RMH Invoice Ninja] Invitation missing link for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        if ( $this->cache_ttl > 0 ) {
+            set_transient( $cache_key, $link, $this->cache_ttl );
+        }
+
+        return $link;
+    }
+
+    /**
+     * Extract the first invitation entry from the API response.
+     *
+     * @param array $data Decoded response data.
+     * @return array|null
+     */
+    private function extract_first_invitation( array $data ): ?array {
+        $queue = [ $data ];
+        while ( $queue ) {
+            $current = array_shift( $queue );
+            if ( ! is_array( $current ) ) {
+                continue;
+            }
+
+            if ( isset( $current['invitations'] ) && is_array( $current['invitations'] ) ) {
+                $list = $current['invitations'];
+                if ( isset( $list['data'] ) && is_array( $list['data'] ) ) {
+                    $list = $list['data'];
+                }
+                foreach ( $list as $invitation ) {
+                    if ( is_array( $invitation ) ) {
+                        return $invitation;
+                    }
+                }
+            }
+
+            foreach ( $current as $value ) {
+                if ( is_array( $value ) ) {
+                    $queue[] = $value;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -10,6 +10,8 @@
 
 if (!defined('ABSPATH')) exit;
 
+require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
+
 class Printcom_Order_Tracker {
     const OPT_SETTINGS     = 'printcom_ot_settings';
     const OPT_MAPPINGS     = 'printcom_ot_mappings';
@@ -70,23 +72,31 @@ class Printcom_Order_Tracker {
     public function register_settings() {
         register_setting(self::OPT_SETTINGS, self::OPT_SETTINGS, [$this,'sanitize_settings']);
         add_settings_section('printcom_ot_section','API-instellingen','__return_false',self::OPT_SETTINGS);
+        add_settings_section('printcom_ot_invoice_ninja','Invoice Ninja','__return_false',self::OPT_SETTINGS);
         $s = $this->get_settings();
-        $add=function($k,$label,$html,$desc=''){
-            add_settings_field($k,$label,function() use($html,$desc){ echo $html; if($desc) echo '<p class="description">'.$desc.'</p>'; },self::OPT_SETTINGS,'printcom_ot_section');
+        $add=function($section,$k,$label,$html,$desc=''){
+            add_settings_field($k,$label,function() use($html,$desc){ echo $html; if($desc) echo '<p class="description">'.$desc.'</p>'; },self::OPT_SETTINGS,$section);
         };
-        $add('api_base_url','API Base URL',sprintf('<input type="url" name="%s[api_base_url]" value="%s" class="regular-text" placeholder="https://api.print.com"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['api_base_url']??'https://api.print.com')));
-        $add('auth_url','Auth URL (login)',sprintf('<input type="url" name="%s[auth_url]" value="%s" class="regular-text" placeholder="https://api.print.com/login"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['auth_url']??'https://api.print.com/login')),'Voor Print.com: <code>https://api.print.com/login</code>.');
+        $add('printcom_ot_section','api_base_url','API Base URL',sprintf('<input type="url" name="%s[api_base_url]" value="%s" class="regular-text" placeholder="https://api.print.com"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['api_base_url']??'https://api.print.com')));
+        $add('printcom_ot_section','auth_url','Auth URL (login)',sprintf('<input type="url" name="%s[auth_url]" value="%s" class="regular-text" placeholder="https://api.print.com/login"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['auth_url']??'https://api.print.com/login')),'Voor Print.com: <code>https://api.print.com/login</code>.');
         ob_start(); ?>
             <select name="<?php echo esc_attr(self::OPT_SETTINGS); ?>[grant_type]">
                 <option value="password" <?php selected($s['grant_type']??'password','password'); ?>>password (/login)</option>
                 <option value="client_credentials" <?php selected($s['grant_type']??'password','client_credentials'); ?>>client_credentials (fallback)</option>
             </select>
-        <?php $add('grant_type','Grant type',ob_get_clean());
-        $add('client_id','Client ID (optioneel)',sprintf('<input type="text" name="%s[client_id]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['client_id']??'')));
-        $add('client_secret','Client Secret (optioneel)',sprintf('<input type="password" name="%s[client_secret]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['client_secret']??'')));
-        $add('username','Username',sprintf('<input type="text" name="%s[username]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['username']??'')));
-        $add('password','Password',sprintf('<input type="password" name="%s[password]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['password']??'')));
-        $add('default_cache_ttl','Cache (minuten)',sprintf('<input type="number" min="0" step="1" name="%s[default_cache_ttl]" value="%d" class="small-text"/>',esc_attr(self::OPT_SETTINGS),isset($s['default_cache_ttl'])?(int)$s['default_cache_ttl']:5),'HOT=5m, COLD=24u.');
+        <?php $add('printcom_ot_section','grant_type','Grant type',ob_get_clean());
+        $add('printcom_ot_section','client_id','Client ID (optioneel)',sprintf('<input type="text" name="%s[client_id]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['client_id']??'')));
+        $add('printcom_ot_section','client_secret','Client Secret (optioneel)',sprintf('<input type="password" name="%s[client_secret]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['client_secret']??'')));
+        $add('printcom_ot_section','username','Username',sprintf('<input type="text" name="%s[username]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['username']??'')));
+        $add('printcom_ot_section','password','Password',sprintf('<input type="password" name="%s[password]" value="%s" class="regular-text"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['password']??'')));
+        $add('printcom_ot_section','default_cache_ttl','Cache (minuten)',sprintf('<input type="number" min="0" step="1" name="%s[default_cache_ttl]" value="%d" class="small-text"/>',esc_attr(self::OPT_SETTINGS),isset($s['default_cache_ttl'])?(int)$s['default_cache_ttl']:5),'HOT=5m, COLD=24u.');
+
+        $enabled_checked = checked(!empty($s['rmh_integration_enabled']), true, false);
+        $add('printcom_ot_invoice_ninja','rmh_integration_enabled','Integratie inschakelen',sprintf('<label><input type="checkbox" name="%1$s[rmh_integration_enabled]" value="1" %2$s/> Schakel Invoice Ninja integratie in</label>',esc_attr(self::OPT_SETTINGS),$enabled_checked),'Toon de betaallink op de track-&-trace pagina.');
+        $add('printcom_ot_invoice_ninja','rmh_in_base_url','Invoice Ninja Base URL',sprintf('<input type="url" name="%1$s[rmh_in_base_url]" value="%2$s" class="regular-text" placeholder="https://invoicing.co"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['rmh_in_base_url']??'')),'Bijvoorbeeld: <code>https://invoicing.co</code>.');
+        $add('printcom_ot_invoice_ninja','rmh_in_api_token','API Token',sprintf('<input type="password" name="%1$s[rmh_in_api_token]" value="%2$s" class="regular-text" autocomplete="new-password"/>',esc_attr(self::OPT_SETTINGS),esc_attr($s['rmh_in_api_token']??'')),'Gebruik een Invoice Ninja v5 API token.');
+        $cache_minutes = isset($s['rmh_in_cache_minutes']) ? (int) $s['rmh_in_cache_minutes'] : 10;
+        $add('printcom_ot_invoice_ninja','rmh_in_cache_minutes','Cache (minuten)',sprintf('<input type="number" min="0" step="1" name="%1$s[rmh_in_cache_minutes]" value="%2$d" class="small-text"/>',esc_attr(self::OPT_SETTINGS),$cache_minutes),'Bewaar uitnodigingslinks tijdelijk (0 = geen cache).');
     }
 
     public function sanitize_settings($in){
@@ -99,7 +109,32 @@ class Printcom_Order_Tracker {
         $o['username']=trim(sanitize_text_field($in['username']??''));
         $o['password']=trim((string)($in['password']??''));
         $o['default_cache_ttl']=max(0,(int)($in['default_cache_ttl']??5));
+        $o['rmh_integration_enabled']=!empty($in['rmh_integration_enabled'])?1:0;
+        $o['rmh_in_base_url']=$this->normalize_invoice_ninja_base_url($in['rmh_in_base_url']??'');
+        $o['rmh_in_api_token']=trim(sanitize_text_field($in['rmh_in_api_token']??''));
+        $o['rmh_in_cache_minutes']=max(0,(int)($in['rmh_in_cache_minutes']??10));
         return $o;
+    }
+
+    private function normalize_invoice_ninja_base_url($url): string {
+        if (!is_string($url)) {
+            return '';
+        }
+
+        $normalized = trim($url);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $normalized = preg_replace('#/+$#', '', $normalized);
+        if (stripos($normalized, 'http://') === 0) {
+            $normalized = 'https://' . substr($normalized, 7);
+        }
+        if (stripos($normalized, 'https://') !== 0) {
+            return '';
+        }
+
+        return sanitize_text_field($normalized);
     }
 
     public function settings_page() {
@@ -491,6 +526,18 @@ class Printcom_Order_Tracker {
         }
         $ship_addr = $this->extract_primary_shipping_address($data);
         $nl_status = $this->human_status($data); // geeft NL: "Deels verzonden", "Verzonden", etc.
+
+        $invoice_cta_html = '';
+        $invoice_id = $this->resolve_invoice_ninja_invoice_id($map, $data, $own, $orderNum);
+        if ($invoice_id && function_exists('rmh_get_invoice_ninja_client_singleton')) {
+            $client = rmh_get_invoice_ninja_client_singleton();
+            if ($client instanceof RMH_InvoiceNinja_Client) {
+                $portal_link = $client->get_invoice_portal_link($invoice_id);
+                if ($portal_link) {
+                    $invoice_cta_html = '<div class="rmh-invoice-cta"><a class="rmh-btn rmh-btn-pay" target="_blank" rel="noopener" href="' . esc_url($portal_link) . '">Factuur bekijken / betalen</a></div>';
+                }
+            }
+        }
     
 
         // prioriteit voor warming
@@ -531,6 +578,9 @@ class Printcom_Order_Tracker {
         $overall_status = $this->determine_overall_order_status($data);
 
         $html  = '<div class="rmh-ot">';
+        if ($invoice_cta_html) {
+            $html .= $invoice_cta_html;
+        }
         // GEEN header-row meer
 
         $summary_html = sprintf(
@@ -696,6 +746,70 @@ class Printcom_Order_Tracker {
 
         return $html;
         }
+
+    private function resolve_invoice_ninja_invoice_id($map_entry, array $order_data, string $own_order, string $print_order): ?string {
+        if (!is_array($map_entry)) {
+            $map_entry = [];
+        }
+
+        $candidates = [];
+
+        if (!empty($map_entry['invoice_id'])) {
+            $candidates[] = $map_entry['invoice_id'];
+        }
+
+        foreach (['invoiceId','invoice_id','invoiceUuid','invoice_uuid','invoiceNumber','invoice_number'] as $field) {
+            if (!empty($order_data[$field])) {
+                $candidates[] = $order_data[$field];
+            }
+        }
+
+        if (!empty($order_data['invoiceIds']) && is_array($order_data['invoiceIds'])) {
+            foreach ($order_data['invoiceIds'] as $value) {
+                if (is_scalar($value) && trim((string) $value) !== '') {
+                    $candidates[] = $value;
+                    break;
+                }
+            }
+        }
+
+        if (!empty($order_data['financial']) && is_array($order_data['financial'])) {
+            foreach (['invoiceId','invoice_id','invoiceUuid','invoice_uuid'] as $field) {
+                if (!empty($order_data['financial'][$field])) {
+                    $candidates[] = $order_data['financial'][$field];
+                }
+            }
+        }
+
+        $invoice_id = '';
+        foreach ($candidates as $candidate) {
+            if (is_scalar($candidate)) {
+                $candidate = trim((string) $candidate);
+                if ($candidate !== '') {
+                    $invoice_id = $candidate;
+                    break;
+                }
+            }
+        }
+
+        /**
+         * Bepaal het Invoice Ninja ID voor deze order.
+         *
+         * @param string $invoice_id  Huidige gevonden invoice ID (kan leeg zijn).
+         * @param array  $order_data  Orderdata van de Print.com API.
+         * @param array  $map_entry   Mapping info voor deze order.
+         * @param string $own_order   Eigen ordernummer.
+         * @param string $print_order Print.com ordernummer.
+         */
+        $invoice_id = apply_filters('rmh_invoice_ninja_invoice_id', $invoice_id, $order_data, $map_entry, $own_order, $print_order);
+        if (!is_string($invoice_id)) {
+            $invoice_id = '';
+        }
+
+        $invoice_id = trim($invoice_id);
+
+        return $invoice_id !== '' ? $invoice_id : null;
+    }
 
     private function pretty_product_title(array $item): string {
         $qty  = isset($item['quantity']) ? (int)$item['quantity'] : 1;
@@ -1571,6 +1685,38 @@ class Printcom_Order_Tracker {
         $ph=0; foreach($hot as $o){ if($ph>=$hot_limit)break; $d=$this->api_get_order($o['order']); if(!is_wp_error($d)) set_transient(self::TRANSIENT_PREFIX.md5($o['order']),$d,$this->dynamic_cache_ttl_for($d)); $ph++; }
         $pc=0; foreach($cold as $o){ if($pc>=$cold_limit)break; $d=$this->api_get_order($o['order']); if(!is_wp_error($d)) set_transient(self::TRANSIENT_PREFIX.md5($o['order']),$d,$this->dynamic_cache_ttl_for($d)); $pc++; }
     }
+}
+
+/**
+ * Verkrijg een gedeelde Invoice Ninja client op basis van de huidige instellingen.
+ *
+ * @return RMH_InvoiceNinja_Client|null
+ */
+function rmh_get_invoice_ninja_client_singleton() {
+    static $instance = null;
+    static $state_hash = null;
+
+    $settings = get_option(Printcom_Order_Tracker::OPT_SETTINGS, []);
+    $enabled  = !empty($settings['rmh_integration_enabled']);
+    $base     = isset($settings['rmh_in_base_url']) ? sanitize_text_field($settings['rmh_in_base_url']) : '';
+    $token    = isset($settings['rmh_in_api_token']) ? (string) $settings['rmh_in_api_token'] : '';
+    $cache    = isset($settings['rmh_in_cache_minutes']) ? absint($settings['rmh_in_cache_minutes']) : 10;
+
+    $hash = md5(wp_json_encode([$enabled, $base, $token, $cache]));
+    if ($state_hash === $hash) {
+        return $instance;
+    }
+
+    $state_hash = $hash;
+
+    if (!$enabled || $base === '' || trim($token) === '') {
+        $instance = null;
+        return null;
+    }
+
+    $instance = new RMH_InvoiceNinja_Client($base, trim($token), $cache);
+
+    return $instance;
 }
 
 /* ===== Hooks ===== */


### PR DESCRIPTION
## Summary
- add an Invoice Ninja settings section with toggle, base URL normalization, API token and cache controls
- implement an RMH_InvoiceNinja_Client to fetch and cache invitation portal links via the WordPress HTTP API
- render the Invoice Ninja payment CTA on order tracker pages when a link is available and add basic styling

## Testing
- php -l printcom-order-tracker.php
- php -l includes/class-rmh-invoice-ninja-client.php


------
https://chatgpt.com/codex/tasks/task_e_68c8a8102000832c83b534c26c771f67