### PR TITLE
Add Invoice Ninja portal link integration

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -75,3 +75,9 @@
 .btn--track{background:#E53935;color:#fff;border-color:#B71C1C}
 .btn--track[aria-disabled="true"]{background:#ffcdd2;border-color:#ef9a9a;color:#B71C1C;cursor:not-allowed}
 
+/* Invoice Ninja CTA */
+.rmh-invoice-cta{margin:1rem 0;text-align:right}
+@media(max-width:900px){.rmh-invoice-cta{text-align:center}}
+.rmh-btn.rmh-btn-pay{display:inline-block;padding:.6rem 1rem;border-radius:.375rem;text-decoration:none;background-color:var(--rmh-btn-pay-bg,#0B63C4);color:#fff;border:1px solid var(--rmh-btn-pay-border,#0B63C4);font-weight:600;transition:background-color .2s ease,border-color .2s ease,color .2s ease}
+.rmh-btn.rmh-btn-pay:hover,.rmh-btn.rmh-btn-pay:focus{background-color:var(--rmh-btn-pay-bg-hover,#094f9c);border-color:var(--rmh-btn-pay-border-hover,#094f9c);color:#fff}
+

--- a/includes/class-rmh-invoice-ninja-client.php
+++ b/includes/class-rmh-invoice-ninja-client.php
@@ -1,0 +1,152 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class RMH_InvoiceNinja_Client {
+    /**
+     * Base URL for the Invoice Ninja instance (without trailing slash).
+     *
+     * @var string
+     */
+    private $base_url;
+
+    /**
+     * API token used for authenticating requests.
+     *
+     * @var string
+     */
+    private $api_token;
+
+    /**
+     * Cache lifetime for invitation links in seconds.
+     *
+     * @var int
+     */
+    private $cache_ttl;
+
+    /**
+     * Constructor.
+     *
+     * @param string $base_url      Invoice Ninja base URL.
+     * @param string $api_token     API token for Invoice Ninja v5.
+     * @param int    $cache_minutes Cache duration in minutes.
+     */
+    public function __construct( string $base_url, string $api_token, int $cache_minutes = 10 ) {
+        $this->base_url  = rtrim( $base_url, '/' );
+        $this->api_token = $api_token;
+        $this->cache_ttl = max( 0, absint( $cache_minutes ) ) * MINUTE_IN_SECONDS;
+    }
+
+    /**
+     * Retrieve the client portal link for a given invoice.
+     *
+     * @param mixed $invoice_id Invoice identifier as provided by Invoice Ninja.
+     * @return string|null
+     */
+    public function get_invoice_portal_link( $invoice_id ): ?string {
+        $invoice = is_scalar( $invoice_id ) ? trim( (string) $invoice_id ) : '';
+        if ( $invoice === '' ) {
+            return null;
+        }
+
+        $cache_key = 'rmh_in_invit_' . md5( $invoice );
+        if ( $this->cache_ttl > 0 ) {
+            $cached = get_transient( $cache_key );
+            if ( is_string( $cached ) && $cached !== '' ) {
+                return $cached;
+            }
+        }
+
+        $url  = $this->base_url . '/api/v1/invoices/' . rawurlencode( $invoice ) . '?include=invitations';
+        $args = [
+            'timeout' => 10,
+            'headers' => [
+                'X-API-Token'      => $this->api_token,
+                'X-Requested-With' => 'XMLHttpRequest',
+                'Accept'           => 'application/json',
+                'User-Agent'       => 'RMH-Order-Tracker (+WordPress)',
+            ],
+        ];
+
+        $response = wp_remote_get( $url, $args );
+        if ( is_wp_error( $response ) ) {
+            error_log( '[RMH Invoice Ninja] HTTP error for invoice ' . sanitize_text_field( $invoice ) . ': ' . $response->get_error_message() );
+            return null;
+        }
+
+        $status = wp_remote_retrieve_response_code( $response );
+        if ( $status < 200 || $status >= 300 ) {
+            error_log( '[RMH Invoice Ninja] Unexpected status ' . $status . ' for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+        if ( ! is_array( $data ) ) {
+            error_log( '[RMH Invoice Ninja] Invalid JSON response for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        $invitation = $this->extract_first_invitation( $data );
+        if ( ! $invitation ) {
+            error_log( '[RMH Invoice Ninja] No invitation found for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        $link = '';
+        if ( ! empty( $invitation['link'] ) ) {
+            $link = (string) $invitation['link'];
+        } elseif ( ! empty( $invitation['key'] ) ) {
+            $link = $this->base_url . '/client/invoice/' . rawurlencode( (string) $invitation['key'] );
+        }
+
+        $link = trim( $link );
+        if ( $link === '' ) {
+            error_log( '[RMH Invoice Ninja] Invitation missing link for invoice ' . sanitize_text_field( $invoice ) . '.' );
+            return null;
+        }
+
+        if ( $this->cache_ttl > 0 ) {
+            set_transient( $cache_key, $link, $this->cache_ttl );
+        }
+
+        return $link;
+    }
+
+    /**
+     * Extract the first invitation entry from the API response.
+     *
+     * @param array $data Decoded response data.
+     * @return array|null
+     */
+    private function extract_first_invitation( array $data ): ?array {
+        $queue = [ $data ];
+        while ( $queue ) {
+            $current = array_shift( $queue );
+            if ( ! is_array( $current ) ) {
+                continue;
+            }
+
+            if ( isset( $current['invitations'] ) && is_array( $current['invitations'] ) ) {
+                $list = $current['invitations'];
+                if ( isset( $list['data'] ) && is_array( $list['data'] ) ) {
+                    $list = $list['data'];
+                }
+                foreach ( $list as $invitation ) {
+                    if ( is_array( $invitation ) ) {
+                        return $invitation;
+                    }
+                }
+            }
+
+            foreach ( $current as $value ) {
+                if ( is_array( $value ) ) {
+                    $queue[] = $value;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Tokens worden automatisch vernieuwd. Ontworpen om goed samen te werken met **Div
 ## Features
 - Automatisch pagina’s aanmaken/bijwerken per ordernummer
 - Orderstatus, producten en Track & Trace links tonen
+- Optionele betaallink-knop via Invoice Ninja uitnodigingen
 - Zoekformulier op ordernummer + postcode via shortcode [print_order_lookup]
 - Cache instelbaar (default 30 minuten)
 - Ondersteuning voor eigen afbeelding per orderpagina


### PR DESCRIPTION
## Summary
- add an Invoice Ninja settings section with toggle, base URL normalization, API token and cache controls
- implement an RMH_InvoiceNinja_Client to fetch and cache invitation portal links via the WordPress HTTP API
- render the Invoice Ninja payment CTA on order tracker pages when a link is available, restricting it to logged-in viewers, and add basic styling
- bump the plugin version to 2.3.0 and update related documentation and stylesheet cache busting

## Testing
- php -l printcom-order-tracker.php
- php -l includes/class-rmh-invoice-ninja-client.php

------
https://chatgpt.com/codex/tasks/task_e_68c8a8102000832c83b534c26c771f67