### PR TITLE
Add invoice number lookup support for Invoice Ninja integration

### DIFF
--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.3.4
+ * Version:     2.3.5
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -1570,7 +1570,7 @@ class Printcom_Order_Tracker {
         global $post;
         $content = $post->post_content ?? '';
         if (has_shortcode($content, 'print_order_status')) {
-            wp_enqueue_style('rmh-ot-style', plugins_url('assets/css/order-tracker.css', __FILE__), [], '2.3.4');
+            wp_enqueue_style('rmh-ot-style', plugins_url('assets/css/order-tracker.css', __FILE__), [], '2.3.5');
         }
         if (has_shortcode($content, 'print_order_lookup')) {
             wp_enqueue_style('rmh-order-lookup', plugins_url('assets/css/order-lookup.css', __FILE__), [], '2.1.4');


### PR DESCRIPTION
## Summary
- add fallback lookup that resolves hashed Invoice Ninja IDs from invoice numbers and reuse cached results
- share HTTP request helpers, cache miss handling, and store resolved IDs for the invitation cache
- bump the plugin version to 2.3.5 and update the enqueued stylesheet version

## Testing
- php -l includes/class-rmh-invoice-ninja-client.php
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68c976d87ab8832cbf62ba0b0f0201d9