### PR TITLE
Bump plugin version to 2.4.0

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -75,11 +75,29 @@
 .btn--track{background:#E53935;color:#fff;border-color:#B71C1C}
 .btn--track[aria-disabled="true"]{background:#ffcdd2;border-color:#ef9a9a;color:#B71C1C;cursor:not-allowed}
 
+/* Invoice Ninja factuurkaart */
+.rmh-invoice-card{background:#fff;border:1px solid #eee;border-radius:16px;padding:18px;margin:0 auto 12px;max-width:1100px;box-shadow:0 6px 12px rgba(15,23,42,.05)}
+.rmh-invoice-card__header{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.rmh-invoice-card__title{margin:0;font-size:1.15rem;font-weight:700;color:#232323}
+.rmh-invoice-card__badge{display:inline-flex;align-items:center;padding:4px 12px;border-radius:999px;font-size:.85rem;font-weight:600;color:#fff}
+.rmh-invoice-card__badge--paid{background:#198754}
+.rmh-invoice-card__badge--open{background:#E53935}
+.rmh-invoice-card__meta{margin-top:8px;display:flex;flex-wrap:wrap;gap:8px 18px;font-size:.95rem;color:#232323}
+.rmh-invoice-card__meta-item{display:flex;align-items:center;gap:6px}
+.rmh-invoice-card__meta-label{font-weight:600}
+.rmh-invoice-card__meta-small{margin-top:4px;font-size:.85rem;color:#6c757d}
+.rmh-invoice-card__summary{margin-top:14px;font-size:1.05rem;font-weight:500;color:#232323;line-height:1.5}
+.rmh-invoice-card__summary-count,.rmh-invoice-card__summary-status{font-weight:600}
+@media(max-width:900px){
+  .rmh-invoice-card{margin:0 12px 16px;padding:16px}
+  .rmh-invoice-card__header{align-items:flex-start}
+}
+
 /* Invoice Ninja CTA */
-.rmh-invoice-cta{margin:1rem 0;text-align:right}
+.rmh-invoice-cta{margin:.75rem auto 1.5rem;text-align:right;max-width:1100px}
 @media(max-width:900px){.rmh-invoice-cta{text-align:center}}
 .rmh-btn.rmh-btn-pay{display:inline-block;padding:.6rem 1rem;border-radius:.375rem;text-decoration:none;background-color:var(--rmh-btn-pay-bg,#0B63C4);color:#fff;border:1px solid var(--rmh-btn-pay-border,#0B63C4);font-weight:600;transition:background-color .2s ease,border-color .2s ease,color .2s ease}
 .rmh-btn.rmh-btn-pay:hover,.rmh-btn.rmh-btn-pay:focus{background-color:var(--rmh-btn-pay-bg-hover,#094f9c);border-color:var(--rmh-btn-pay-border-hover,#094f9c);color:#fff}
-.rmh-invoice-admin-hint{margin:1rem 0;text-align:right;font-size:.875rem;color:#6c757d}
+.rmh-invoice-admin-hint{margin:1rem auto;text-align:right;font-size:.875rem;color:#6c757d;max-width:1100px}
 @media(max-width:900px){.rmh-invoice-admin-hint{text-align:center}}
 


### PR DESCRIPTION
## Summary
- bump the plugin header version metadata to 2.4.0
- update the enqueued stylesheet version to 2.4.0 to keep asset cache busting in sync

## Testing
- php -l printcom-order-tracker.php
- php -l includes/class-rmh-invoice-ninja-client.php

------
https://chatgpt.com/codex/tasks/task_e_68ca780e5850832c93126645344f63c3