### PR TITLE
Update invoice card styling and totals

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -76,7 +76,7 @@
 .btn--track[aria-disabled="true"]{background:#ffcdd2;border-color:#ef9a9a;color:#B71C1C;cursor:not-allowed}
 
 /* Invoice Ninja factuurkaart */
-.rmh-invoice-card{background:#fff;border:1px solid #eee;border-radius:16px;padding:18px;margin:0 auto 12px;max-width:1100px;box-shadow:0 6px 12px rgba(15,23,42,.05)}
+.rmh-invoice-card{background:#F8E9D2;border:2px solid #24325F;border-radius:16px;padding:18px;max-width:1100px;box-shadow:0 6px 12px rgba(15,23,42,.05)}
 .rmh-invoice-card__header{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
 .rmh-invoice-card__title{margin:0;font-size:1.15rem;font-weight:700;color:#232323}
 .rmh-invoice-card__badge{display:inline-flex;align-items:center;padding:4px 12px;border-radius:999px;font-size:.85rem;font-weight:600;color:#fff}

--- a/includes/class-rmh-invoice-ninja-client.php
+++ b/includes/class-rmh-invoice-ninja-client.php
@@ -62,6 +62,7 @@ class RMH_InvoiceNinja_Client {
      *     is_paid:bool|null,
      *     invoice_number:?string,
      *     invoice_date:?string,
+     *     due_date:?string,
      *     total:?float,
      *     balance:?float,
      *     subtotal:?float,
@@ -448,6 +449,7 @@ class RMH_InvoiceNinja_Client {
             'is_paid'        => $this->determine_invoice_paid_status( $payload ),
             'invoice_number' => $this->extract_string_value( $invoice, [ 'invoice_number', 'number', 'id_number', 'po_number' ] ),
             'invoice_date'   => $this->extract_string_value( $invoice, [ 'date', 'invoice_date', 'invoicedate', 'created_at' ] ),
+            'due_date'       => $this->extract_string_value( $invoice, [ 'due_date', 'dueDate', 'due', 'due_on', 'due_at', 'expires_at', 'valid_until' ] ),
             'total'          => $this->extract_numeric_value( $invoice, [ 'amount', 'total', 'amount_raw' ] ),
             'balance'        => $this->extract_numeric_value( $invoice, [ 'balance', 'balance_raw', 'outstanding', 'amount_due', 'amountdue' ] ),
             'subtotal'       => $this->extract_numeric_value( $invoice, [ 'subtotal', 'sub_total', 'amount_less_tax', 'total_less_tax' ] ),
@@ -477,6 +479,7 @@ class RMH_InvoiceNinja_Client {
             'is_paid'        => null,
             'invoice_number' => null,
             'invoice_date'   => null,
+            'due_date'       => null,
             'total'          => null,
             'balance'        => null,
             'subtotal'       => null,
@@ -502,7 +505,7 @@ class RMH_InvoiceNinja_Client {
             }
         }
 
-        foreach ( [ 'invoice_number', 'invoice_date', 'currency' ] as $string_key ) {
+        foreach ( [ 'invoice_number', 'invoice_date', 'due_date', 'currency' ] as $string_key ) {
             if ( isset( $details[ $string_key ] ) && is_string( $details[ $string_key ] ) ) {
                 $value = trim( $details[ $string_key ] );
                 if ( $value !== '' ) {


### PR DESCRIPTION
## Summary
- update the invoice card styling to match the new design specs
- extend invoice detail handling with due date support and revised totals display
- bump plugin version to 2.4.3

## Testing
- php -l printcom-order-tracker.php
- php -l includes/class-rmh-invoice-ninja-client.php

------
https://chatgpt.com/codex/tasks/task_e_68cac41f6e60832caaddc3f1021d95f1