### PR TITLE
Apply dynamic order summary across breakpoints

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -80,6 +80,7 @@
 .rmh-invoice-card__header{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
 .rmh-invoice-card__title{margin:0;font-size:1.15rem;font-weight:700;color:#232323}
 .rmh-invoice-card__badge{display:inline-flex;align-items:center;padding:4px 12px;border-radius:999px;font-size:.85rem;font-weight:600;color:#fff}
+.rmh-invoice-card__badge-text-mobile{display:none}
 .rmh-invoice-card__badge--paid{background:#198754}
 .rmh-invoice-card__badge--open{background:#E53935}
 .rmh-invoice-card__meta{margin-top:12px;display:flex;flex-direction:column;gap:10px;font-size:.95rem;color:#232323}
@@ -94,6 +95,12 @@
 }
 .rmh-order-progress{margin:12px auto 18px;max-width:1100px;font-size:1.05rem;font-weight:500;color:#232323;line-height:1.5;text-align:left}
 .rmh-order-progress__count,.rmh-order-progress__status{font-weight:600}
+.rmh-ot__summary-text--mobile{display:none}
+@media(max-width:600px){
+  .rmh-ot__summary-text--desktop{display:none}
+  .rmh-ot__summary-text--mobile{display:inline}
+}
+
 @media(max-width:900px){
   .rmh-order-progress{margin:12px 12px 18px}
 }
@@ -107,9 +114,13 @@
   .rmh-invoice-card{margin:0 16px 18px;padding:24px;border-radius:18px;border:1px solid rgba(36,50,95,.14);background:#FBEEDA;box-shadow:0 14px 28px rgba(15,23,42,.12)}
   .rmh-invoice-card__header{flex-direction:column;align-items:flex-start;gap:12px;margin-bottom:20px;width:100%}
   .rmh-invoice-card__title{margin:0;font-size:1.12rem}
+  .rmh-invoice-card__badge-text-desktop{display:none}
+  .rmh-invoice-card__badge-text-mobile{display:inline}
+  .rmh-invoice-card__badge--mobile-hidden{display:none}
   .rmh-invoice-card__badge{display:inline-flex;align-items:center;justify-content:center;padding:6px 18px;border-radius:999px;background:#FFF4F3;border:1px solid #F3B4B4;color:#B71C1C;line-height:1;transition:background-color .25s ease,color .25s ease,border-color .25s ease,box-shadow .25s ease,transform .2s ease}
   .rmh-invoice-card__badge--open{background:#FFF4F3;border-color:#F3B4B4;color:#B71C1C}
   .rmh-invoice-card__badge--paid{background:#EEF7F0;border-color:#A8D5B7;color:#146C43}
+  .rmh-invoice-card__badge--partial{background:#FFF8EB;border-color:#F6C67A;color:#8C4A0E}
   .rmh-invoice-card__badge:focus-visible{outline:3px solid #24325F;outline-offset:2px}
   .rmh-invoice-card__meta{margin-top:0;gap:16px;font-size:.95rem}
   .rmh-invoice-card__meta-item{display:flex;flex-direction:column;align-items:flex-start;gap:6px;padding-bottom:12px;border-bottom:1px solid rgba(36,50,95,.08)}


### PR DESCRIPTION
## Summary
- replace the legacy desktop-only intro sentence with the new dynamic order and invoice summary for all breakpoints
- keep the mobile-specific badge adjustments while bumping the plugin version to 2.4.8 for cache busting

## Testing
- php -l printcom-order-tracker.php
- php -l includes/class-rmh-invoice-ninja-client.php

------
https://chatgpt.com/codex/tasks/task_e_68cb3b3b8874832c9259fea7dc0c14fb