### PR TITLE
Adjust order overview spacing

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -16,6 +16,10 @@
 .rmh-ot__lookup-form .btn{grid-column:1/-1;width:100%;font-weight:700}
 .rmh-ot__items{display:flex;flex-direction:column;width:100%;max-width:1200px;margin-left:auto;margin-right:auto;}
 .rmh-ot__items h3{margin:10px 0;text-align:center;margin-left:0}
+.rmh-ot__items h3.rmh-ot__overview-title{margin-top:50px;margin-bottom:10px}
+@media(min-width:901px){
+  .rmh-ot__items h3.rmh-ot__overview-title{margin-top:80px}
+}
 .rmh-ot__grid{display:block!important}
 .rmh-ot__items::after{content:"";display:block;clear:both}
 .rmh-ot__item{display:block;border:1px solid #eee;border-radius:16px;background:#fff;padding:18px;margin:18px auto;width:100%;max-width:1100px}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.11
+ * Version:     2.4.12
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.11';
+    public const PLUGIN_VERSION = '2.4.12';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';
@@ -736,7 +736,7 @@ class Printcom_Order_Tracker {
             }
         }
 
-        $html .= '<div class="rmh-ot__items"><h3>Overzicht van je bestelling</h3>';
+        $html .= '<div class="rmh-ot__items"><h3 class="rmh-ot__overview-title">Overzicht van je bestelling</h3>';
         if($items && is_array($items)){
             $html .= '<div class="rmh-ot__grid">';
             foreach($items as $index=>$it){


### PR DESCRIPTION
## Summary
- add a dedicated class to the order overview heading
- introduce responsive spacing so the heading gets 50px top margin on mobile and 80px on desktop
- bump plugin version to 2.4.12

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbeb577a2c832c9e700d9fb0ba2040