### PR TITLE
Fix mobile invoice total styling when balance absent

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -128,7 +128,7 @@
   .rmh-invoice-card__badge:focus-visible{outline:3px solid #24325F;outline-offset:2px}
   .rmh-invoice-card__meta{margin-top:0;gap:16px;font-size:.95rem}
   .rmh-invoice-card__meta-item{display:flex;flex-direction:column;align-items:flex-start;gap:6px;padding-bottom:12px;border-bottom:1px solid rgba(36,50,95,.08)}
-  .rmh-invoice-card__meta-item:last-child{border:2px solid #F3B4B4}
+  .rmh-invoice-card__meta-item:last-child:not(.rmh-invoice-card__meta-item--amount-highlight){border-bottom:none;padding-bottom:0}
   .rmh-invoice-card__meta-label{color:#5d6673;font-size:.85rem;font-weight:600;letter-spacing:.01em}
   .rmh-invoice-card__meta-item span:last-child{color:#232323;font-weight:600;font-size:1rem}
   .rmh-invoice-card__meta-item--date{gap:4px;padding-bottom:10px}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.12
+ * Version:     2.4.13
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.12';
+    public const PLUGIN_VERSION = '2.4.13';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- prevent the mobile invoice total row from inheriting the outstanding amount highlight when no balance is due
- bump the plugin version to 2.4.13

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc0c2cf85c832c9e758f797c580a5e