### PR TITLE
Refine invoice card layout and bump version

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -81,32 +81,34 @@
 
 /* Invoice Ninja factuurkaart */
 .rmh-ot__items--invoice>h3{margin:4px auto 12px}
-.rmh-invoice-card{margin:0 16px 18px;padding:24px;border-radius:18px;border:1px solid rgba(36,50,95,.14);background:#FBEEDA;box-shadow:0 14px 28px rgba(15,23,42,.12);max-width:1100px}
-.rmh-invoice-card__header{display:flex;flex-direction:column;align-items:flex-start;gap:12px;flex-wrap:wrap;margin-bottom:20px;width:100%}
-.rmh-invoice-card__title{margin:0;font-size:1.12rem;font-weight:700;color:#232323}
-.rmh-invoice-card__badge{display:none;align-items:center;justify-content:center;padding:6px 18px;border-radius:999px;background:#FFF4F3;border:1px solid #F3B4B4;color:#B71C1C;line-height:1;transition:background-color .25s ease,color .25s ease,border-color .25s ease,box-shadow .25s ease,transform .2s ease}
+.rmh-invoice-card{margin:0 16px 18px;padding:24px;border-radius:18px;border:1px solid rgba(36,50,95,.1);background:#fff;box-shadow:0 12px 26px rgba(15,23,42,.1);max-width:1100px;display:flex;flex-direction:column;gap:20px}
+.rmh-invoice-card__header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;width:100%;margin-bottom:0}
+.rmh-invoice-card__title{margin:0;font-size:1.16rem;font-weight:700;color:#232323;line-height:1.3}
+.rmh-invoice-card__badge{display:inline-flex;align-items:center;justify-content:center;padding:6px 16px;border-radius:999px;background:#FFF4F3;border:1px solid #F3B4B4;color:#B71C1C;line-height:1;font-weight:600;letter-spacing:.02em;margin-left:auto;white-space:nowrap;transition:background-color .25s ease,color .25s ease,border-color .25s ease,box-shadow .25s ease,transform .2s ease}
 .rmh-invoice-card__badge-text-desktop{display:none}
 .rmh-invoice-card__badge-text-mobile{display:inline}
-.rmh-invoice-card__badge--mobile-hidden{display:none}
-.rmh-invoice-card__badge--open{background:#FFF4F3;border-color:#F3B4B4;color:#B71C1C}
-.rmh-invoice-card__badge--paid{background:#EEF7F0;border-color:#A8D5B7;color:#146C43}
-.rmh-invoice-card__badge--partial{background:#FFF8EB;border-color:#F6C67A;color:#8C4A0E}
+.rmh-invoice-card__badge--mobile-hidden{display:inline-flex}
+.rmh-invoice-card__badge--open{background:#FFF4F3;border-color:#E7A8A3;color:#B71C1C}
+.rmh-invoice-card__badge--paid{background:#F1F8F3;border-color:#9CCFAD;color:#146C43}
+.rmh-invoice-card__badge--partial{background:#FFF8EB;border-color:#F2C27E;color:#8C4A0E}
 .rmh-invoice-card__badge:focus-visible{outline:3px solid #24325F;outline-offset:2px}
 .rmh-invoice-card__meta{margin-top:0;display:flex;flex-direction:column;gap:16px;font-size:.95rem;color:#232323}
 .rmh-invoice-card__meta-item{display:flex;flex-direction:column;align-items:flex-start;gap:6px;padding-bottom:12px;border-bottom:1px solid rgba(36,50,95,.08);line-height:1.5}
-.rmh-invoice-card__meta-label{color:#5d6673;font-size:.85rem;font-weight:600;letter-spacing:.01em}
+.rmh-invoice-card__meta-label{color:#5d6673;font-size:.8rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase}
 .rmh-invoice-card__meta-item span:last-child{color:#232323;font-weight:600;font-size:1rem}
 .rmh-invoice-card__meta-item--subtle{color:#6c757d;font-size:.9rem}
 .rmh-invoice-card__meta-item--amount-subtle span:last-child{font-weight:500;font-size:.94rem;color:#4f5560}
 .rmh-invoice-card__meta-item--amount-base span:last-child{font-size:1.04rem}
-.rmh-invoice-card__meta-item--amount-highlight{order:-1;align-self:stretch;width:100%;background:#FFF9F8;border:2px solid #F3B4B4;border-radius:18px;padding:18px 20px;box-shadow:0 14px 26px rgba(183,28,28,.14);gap:0}
-.rmh-invoice-card__meta-item--amount-highlight .rmh-invoice-card__meta-label{color:#B71C1C;font-size:.92rem}
-.rmh-invoice-card__meta-item--amount-highlight span:last-child{color:#B71C1C;font-size:1.32rem;font-weight:700}
-.rmh-invoice-card__footer{margin-top:28px;display:flex;justify-content:flex-end}
-.rmh-invoice-card__footer .btn{display:inline-flex;align-items:center;justify-content:center;padding:18px 26px;border-radius:18px;font-weight:700;font-size:1.05rem;text-align:center;box-shadow:0 16px 28px rgba(229,57,53,.28);transition:background-color .25s ease,color .25s ease,box-shadow .25s ease,transform .2s ease}
-.rmh-invoice-card__footer .btn--track{background:#D32F2F;border-color:#B71C1C;color:#fff}
-.rmh-invoice-card__footer .btn--track:hover,.rmh-invoice-card__footer .btn--track:focus-visible{background:#B71C1C;border-color:#8E1B1B;color:#fff;box-shadow:0 18px 30px rgba(183,28,28,.32)}
-.rmh-invoice-card__footer .btn--track:active{background:#8E1B1B;border-color:#6A1313;box-shadow:0 10px 20px rgba(106,19,19,.35);transform:translateY(1px)}
+.rmh-invoice-card__meta-item--amount-highlight{order:-1;align-self:stretch;width:100%;background:#FFF7F6;border:1px solid rgba(183,28,28,.35);border-radius:14px;padding:16px 18px;box-shadow:none;gap:4px;border-bottom:none}
+.rmh-invoice-card__meta-item--amount-highlight .rmh-invoice-card__meta-label{color:#B71C1C;font-size:.82rem}
+.rmh-invoice-card__meta-item--amount-highlight span:last-child{color:#B71C1C;font-size:1.28rem;font-weight:700}
+.rmh-invoice-card__footer{margin-top:0;display:flex;justify-content:flex-end;align-items:flex-end;gap:16px}
+.rmh-invoice-card__footer .btn{display:inline-flex;align-items:center;justify-content:center;padding:12px 20px;border-radius:14px;font-weight:600;font-size:1rem;line-height:1;text-align:center;min-height:44px;border:2px solid rgba(36,50,95,.18);background:transparent;color:#24325F;box-shadow:none;transition:background-color .25s ease,color .25s ease,border-color .25s ease,box-shadow .25s ease,transform .2s ease}
+.rmh-invoice-card__footer .btn[aria-label*="betaal"]{background:#D32F2F;border-color:#B71C1C;color:#fff;box-shadow:0 10px 20px rgba(211,47,47,.25)}
+.rmh-invoice-card__footer .btn[aria-label*="betaal"]:hover,.rmh-invoice-card__footer .btn[aria-label*="betaal"]:focus-visible{background:#B71C1C;border-color:#8E1B1B;color:#fff;box-shadow:0 12px 24px rgba(183,28,28,.28)}
+.rmh-invoice-card__footer .btn[aria-label*="betaal"]:active{background:#8E1B1B;border-color:#6A1313;box-shadow:0 8px 16px rgba(106,19,19,.32);transform:translateY(1px)}
+.rmh-invoice-card__footer .btn:not([aria-label*="betaal"]){background:transparent;border-color:rgba(36,50,95,.22);color:#24325F}
+.rmh-invoice-card__footer .btn:not([aria-label*="betaal"]):hover,.rmh-invoice-card__footer .btn:not([aria-label*="betaal"]):focus-visible{border-color:#24325F;color:#24325F;box-shadow:0 6px 14px rgba(36,50,95,.16)}
 .rmh-invoice-card__footer .btn:focus-visible{outline:3px solid #24325F;outline-offset:3px}
 @media(max-width:767px){
   .rmh-invoice-card__footer .btn{width:100%;text-align:center}
@@ -119,32 +121,54 @@
   .rmh-ot__summary-text--mobile{display:inline}
 }
 
+@media(max-width:600px){
+  .rmh-invoice-card{margin:0 12px 18px;padding:22px 20px;border-radius:16px;gap:18px}
+  .rmh-invoice-card__header{flex-wrap:wrap;align-items:flex-start}
+  .rmh-invoice-card__title{font-size:1.08rem}
+  .rmh-invoice-card__badge{margin-left:auto;margin-top:0;margin-bottom:6px;padding:4px 12px;font-size:.78rem}
+  .rmh-invoice-card__meta{gap:14px}
+  .rmh-invoice-card__meta-item{padding-bottom:10px}
+  .rmh-invoice-card__meta-item:last-child{padding-bottom:0;border-bottom:none}
+  .rmh-invoice-card__meta-item--amount-highlight{order:-2;padding:14px 16px;border-radius:12px}
+  .rmh-invoice-card__meta-item--amount-highlight .rmh-invoice-card__meta-label{font-size:.78rem}
+  .rmh-invoice-card__meta-item--amount-highlight span:last-child{font-size:1.4rem}
+  .rmh-invoice-card__meta-item--amount-base{order:-1}
+  .rmh-invoice-card__meta-item--amount-base span:last-child{font-size:1.32rem;font-weight:700}
+  .rmh-invoice-card__meta-item--amount-base .rmh-invoice-card__meta-label{color:#4f5560}
+  .rmh-invoice-card__footer{margin-top:12px;justify-content:flex-end}
+  .rmh-invoice-card__footer .btn{width:100%;min-height:50px;font-size:1.02rem}
+}
+
 @media(max-width:900px){
   .rmh-order-progress{margin:12px 12px 18px}
 }
 @media(min-width:601px){
   .rmh-ot__items--invoice>h3{margin:12px auto 20px}
-  .rmh-invoice-card{margin:auto 24px;padding:28px 32px;border-radius:20px}
-  .rmh-invoice-card__header{flex-direction:row;align-items:center;justify-content:space-between;gap:20px;margin-bottom:24px;width:auto}
+  .rmh-invoice-card{margin:auto 24px;padding:30px 32px;border-radius:20px;gap:24px}
+  .rmh-invoice-card__header{gap:20px}
   .rmh-invoice-card__title{font-size:1.28rem}
   .rmh-invoice-card__badge{display:inline-flex}
   .rmh-invoice-card__badge-text-desktop{display:inline}
   .rmh-invoice-card__badge-text-mobile{display:none}
   .rmh-invoice-card__badge--mobile-hidden{display:inline-flex}
   .rmh-invoice-card__badge:focus-visible{outline-offset:3px}
-  .rmh-invoice-card__meta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px 24px}
-  .rmh-invoice-card__meta-item{padding-bottom:0;gap:8px}
-  .rmh-invoice-card__meta-item--amount-highlight{order:0;grid-column:1/-1;padding:20px 24px;border-radius:22px}
-  .rmh-invoice-card__meta-item--amount-highlight .rmh-invoice-card__meta-label{font-size:.95rem}
-  .rmh-invoice-card__meta-item--amount-highlight span:last-child{font-size:1.4rem}
-  .rmh-invoice-card__footer{margin-top:32px}
-  .rmh-invoice-card__footer .btn{width:auto;padding:18px 32px}
+  .rmh-invoice-card__meta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px 32px;align-items:start}
+  .rmh-invoice-card__meta-item{padding-bottom:0;gap:8px;border-bottom:none}
+  .rmh-invoice-card__meta-item:nth-child(odd){align-items:flex-start;text-align:left}
+  .rmh-invoice-card__meta-item:nth-child(even){align-items:flex-end;text-align:right}
+  .rmh-invoice-card__meta-item--amount-subtle span:last-child{font-size:1rem}
+  .rmh-invoice-card__meta-item--amount-base span:last-child{font-size:1.12rem}
+  .rmh-invoice-card__meta-item--amount-highlight{order:6;grid-column:1/-1;background:transparent;border:0;border-radius:0;padding:0;margin-top:12px;padding-top:18px;border-top:1px solid rgba(36,50,95,.12);display:flex;align-items:flex-end;justify-content:space-between;gap:12px}
+  .rmh-invoice-card__meta-item--amount-highlight .rmh-invoice-card__meta-label{font-size:.85rem}
+  .rmh-invoice-card__meta-item--amount-highlight span:last-child{font-size:1.6rem}
+  .rmh-invoice-card__footer{margin-top:12px;justify-content:flex-end}
+  .rmh-invoice-card__footer .btn{width:auto;padding:14px 28px}
 }
 
 @media(max-width:600px) and (prefers-reduced-motion:reduce){
   .rmh-invoice-card__badge,
   .rmh-invoice-card__footer .btn{transition:none}
-  .rmh-invoice-card__footer .btn--track:active{transform:none}
+  .rmh-invoice-card__footer .btn:active{transform:none}
 }
 
 /* Invoice Ninja CTA button */

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.15
+ * Version:     2.4.16
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.15';
+    public const PLUGIN_VERSION = '2.4.16';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- restyle Invoice Ninja cards with refined spacing, card chrome and typography while keeping the status badge visible across breakpoints
- introduce desktop two-column meta layout with prominent outstanding amount treatment and responsive mobile hierarchy adjustments
- adjust invoice action buttons for paid vs. unpaid states and bump plugin version to 2.4.16

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68cd32504ae8832ca35905adf0f34911