### PR TITLE
Adjust mobile invoice card layout

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -145,19 +145,27 @@
 
 @media(max-width:600px){
   .rmh-invoice-card{margin:0 12px 18px;padding:24px 22px 28px;border-radius:20px;gap:24px}
-  .rmh-invoice-card__header{align-items:center}
-  .rmh-invoice-card__title{font-size:1.08rem}
-  .rmh-invoice-card__badge{margin-left:auto;margin-top:0;margin-bottom:8px;padding:6px 18px;font-size:.8rem}
+  .rmh-invoice-card__header{display:grid;grid-template-columns:minmax(0,1fr) auto;grid-template-areas:"title badge";align-items:start;column-gap:12px;row-gap:12px;padding:10px 0 14px}
+  .rmh-invoice-card__title{grid-area:title;font-size:1.08rem;line-height:1.35;text-align:left}
+  .rmh-invoice-card__badge{grid-area:badge;justify-self:end;align-self:start;margin:0;min-height:40px;padding:8px 20px;font-size:.82rem;white-space:nowrap}
   .rmh-invoice-card__body{gap:22px}
-  .rmh-invoice-card__balance{padding:18px 20px;border-radius:16px;font-size:1rem}
-  .rmh-invoice-card__balance-amount{font-size:1.3rem}
-  .rmh-invoice-card__meta{grid-template-columns:minmax(0,1fr);row-gap:20px}
-  .rmh-invoice-card__meta-column{gap:16px}
-  .rmh-invoice-card__meta-item{column-gap:18px}
+  .rmh-invoice-card__balance{padding:16px 18px;border-radius:16px;font-size:1rem;gap:12px;box-shadow:0 8px 14px rgba(229,57,53,.16)}
+  .rmh-invoice-card__balance-amount{display:none}
+  .rmh-invoice-card__balance--notice{align-items:flex-start}
+  .rmh-invoice-card__balance--notice::before{width:22px;height:22px;background-size:12px;box-shadow:0 4px 10px rgba(229,57,53,.16);margin-top:2px}
+  .rmh-invoice-card__balance-message{font-size:.96rem;line-height:1.4;letter-spacing:.01em}
+  .rmh-invoice-card__meta{grid-template-columns:minmax(0,1fr);row-gap:18px}
+  .rmh-invoice-card__meta-column{gap:14px}
+  .rmh-invoice-card__meta-item{grid-template-columns:minmax(0,1fr);row-gap:6px;align-items:flex-start}
+  .rmh-invoice-card__meta-label,.rmh-invoice-card__meta-value{display:block}
+  .rmh-invoice-card__meta-label{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(35,35,35,.7);line-height:1.2}
+  .rmh-invoice-card__meta-value{font-size:1.02rem;font-weight:600;color:#232323;text-align:left;letter-spacing:normal;text-transform:none;line-height:1.45}
+  .rmh-invoice-card__meta-item--amount-subtle .rmh-invoice-card__meta-value{font-size:1.02rem}
+  .rmh-invoice-card__meta-item--amount-base{display:none}
   .rmh-invoice-card__footer{flex-direction:column;align-items:stretch;gap:22px;margin-top:0;padding-top:20px}
   .rmh-invoice-card__footer-summary{grid-template-columns:1fr;row-gap:6px;font-size:1.14rem}
   .rmh-invoice-card__footer-label{font-size:.94rem;text-align:left}
-  .rmh-invoice-card__footer-amount{font-size:1.5rem}
+  .rmh-invoice-card__footer-amount{font-size:1.5rem;text-align:left}
   .rmh-invoice-card__footer-action{width:100%;display:flex}
   .rmh-invoice-card__cta{width:100%;min-height:52px;font-size:1.02rem}
 }

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.19
+ * Version:     2.4.20
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.19';
+    public const PLUGIN_VERSION = '2.4.20';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- keep the mobile invoice card header spacious and lock the status badge in the top-right corner
- reflow invoice metadata on mobile so labels stack above values with left-aligned amounts and hide duplicate totals outside the footer
- calm the mobile open-invoice notice styling, keep only the footer total prominent, and bump the plugin patch version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbe049b9c832cbeebf71e5579b311