### PR TITLE
Tighten mobile invoice spacing and footer alignment

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -154,11 +154,11 @@
 }
 
 @media(max-width:600px){
-  .rmh-invoice-card{margin:0 12px 18px;padding:24px 22px 28px;border-radius:20px;gap:24px}
-  .rmh-invoice-card__header{display:flex;flex-direction:column;align-items:center;gap:14px;padding:8px 0 12px;text-align:center}
+  .rmh-invoice-card{margin:0 12px 18px;padding:24px 22px 28px;border-radius:20px;gap:16px}
+  .rmh-invoice-card__header{display:flex;flex-direction:column;align-items:center;gap:10px;padding:6px 0 0;text-align:center}
   .rmh-invoice-card__title{font-size:1.12rem;line-height:1.4;text-align:center;width:100%}
   .rmh-invoice-card__badge{display:none}
-  .rmh-invoice-card__status-region{width:100%;margin-bottom:12px}
+  .rmh-invoice-card__status-region{width:100%;margin-bottom:0}
   .rmh-invoice-card__status{padding:12px 14px;gap:10px;box-shadow:0 3px 10px rgba(36,50,95,.08)}
   .rmh-invoice-card__status-icon{width:16px;height:16px;background-size:9px;box-shadow:0 2px 6px rgba(229,57,53,.14)}
   .rmh-invoice-card__status--paid .rmh-invoice-card__status-icon{box-shadow:0 2px 6px rgba(46,125,50,.14)}
@@ -173,10 +173,10 @@
   .rmh-invoice-card__meta-item--amount-total{display:flex;flex-direction:column;font-size:1.08rem}
   .rmh-invoice-card__meta-item--amount-total .rmh-invoice-card__meta-value{font-size:1.14rem;font-weight:700}
   .rmh-invoice-card__meta-item--amount-base .rmh-invoice-card__meta-value{font-weight:600}
-  .rmh-invoice-card__footer{flex-direction:column;align-items:stretch;gap:30px;margin-top:0;padding-top:20px;border-top:1px solid rgba(36,50,95,.2)}
-  .rmh-invoice-card__footer-summary{grid-template-columns:1fr;row-gap:8px;font-size:1.16rem}
+  .rmh-invoice-card__footer{flex-direction:column;align-items:stretch;gap:30px;margin-top:8px;padding-top:20px;border-top:1px solid rgba(36,50,95,.2)}
+  .rmh-invoice-card__footer-summary{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:1.16rem;width:100%}
   .rmh-invoice-card__footer-label{font-size:.96rem;text-align:left;color:#5C5148;font-weight:600;letter-spacing:0;text-transform:none}
-  .rmh-invoice-card__footer-amount{font-size:1.52rem;text-align:left;color:#232323}
+  .rmh-invoice-card__footer-amount{font-size:1.52rem;text-align:right;color:#232323;flex-shrink:0}
   [data-invoice-status="open"] .rmh-invoice-card__footer-label{color:#B71C1C}
   [data-invoice-status="open"] .rmh-invoice-card__footer-amount{color:#E53935}
   .rmh-invoice-card__footer-action{width:100%;display:flex}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.23
+ * Version:     2.4.24
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.23';
+    public const PLUGIN_VERSION = '2.4.24';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- compress the mobile invoice card header spacing for a tighter hierarchy
- align the open balance footer label to the left and amount to the right on mobile
- bump the plugin version to 2.4.24

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce6538e3cc832cba4bcf686e7e5b58