### PR TITLE
Adjust desktop invoice card layout

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -201,6 +201,27 @@
   .rmh-invoice-card__cta{width:auto;padding:14px 32px;min-height:50px}
 }
 
+@media (min-width: 992px) {
+  .rmh-invoice-card{padding:36px;gap:24px}
+  .rmh-invoice-card__header{display:grid;grid-template-columns:1fr;row-gap:18px;align-items:start;justify-items:stretch}
+  .rmh-invoice-card__badge{display:none}
+  .rmh-invoice-card__status-region{margin-top:0;width:100%}
+  .rmh-invoice-card__status{padding:12px 18px;gap:12px;box-shadow:0 6px 18px rgba(36,50,95,.12)}
+  .rmh-invoice-card__status-icon{width:18px;height:18px;background-size:10px}
+  .rmh-invoice-card__status-text{align-items:center}
+  .rmh-invoice-card__body{gap:16px}
+  .rmh-invoice-card__meta{grid-template-columns:repeat(2,minmax(0,1fr));column-gap:56px;row-gap:20px}
+  .rmh-invoice-card__meta-item{grid-template-columns:minmax(0,1fr) auto;column-gap:18px;align-items:end}
+  .rmh-invoice-card__meta-label{text-align:left}
+  .rmh-invoice-card__meta-value{justify-self:end;text-align:right}
+  .rmh-invoice-card__footer{position:relative;margin-top:0;padding-top:28px;border-top:0;align-items:center;gap:24px}
+  .rmh-invoice-card__footer::before{content:"";position:absolute;top:0;left:36px;right:36px;height:1px;background:rgba(36,50,95,.18);border-radius:999px}
+  .rmh-invoice-card__footer-summary{display:flex;align-items:center;column-gap:10px;margin:0}
+  [data-invoice-status="open"] .rmh-invoice-card__footer-summary{font-weight:700}
+  .rmh-invoice-card__footer-action{margin-left:auto}
+  .rmh-invoice-card__cta{min-height:48px}
+}
+
 @media(prefers-reduced-motion:reduce){
   .btn,
   .rmh-invoice-card__badge,

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.24
+ * Version:     2.4.25
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.24';
+    public const PLUGIN_VERSION = '2.4.25';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- refine the desktop invoice card by hiding the badge, stretching the status banner, and tightening spacing within a new ≥992px breakpoint
- restructure the invoice metadata into a two-column grid with right-aligned amounts and add an inset divider with balanced footer actions
- bump the plugin version metadata to 2.4.25

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68ce6ca45e9c832c8e81168600dcbed2