### PR TITLE
Adjust invoice header spacing and bump version

### DIFF
--- a/assets/css/order-tracker.css
+++ b/assets/css/order-tracker.css
@@ -15,7 +15,7 @@
 .rmh-ot__lookup-form input{padding:10px;border:1px solid #ddd;border-radius:8px}
 .rmh-ot__lookup-form .btn{grid-column:1/-1;width:100%;font-weight:700}
 .rmh-ot__items{display:flex;flex-direction:column;width:100%;max-width:1200px;margin-left:auto;margin-right:auto;}
-.rmh-ot__items h3{margin:10px 0;text-align:center;margin-left:0}
+.rmh-ot__items h3{margin:0;text-align:center;margin-left:0}
 .rmh-ot__items h3.rmh-ot__overview-title{margin-top:50px;margin-bottom:10px}
 @media(min-width:901px){
   .rmh-ot__items h3.rmh-ot__overview-title{margin-top:80px}
@@ -203,7 +203,7 @@
 
 @media (min-width: 992px) {
   .rmh-invoice-card{padding:36px;gap:24px}
-  .rmh-invoice-card__header{display:grid;grid-template-columns:1fr;row-gap:18px;align-items:start;justify-items:stretch}
+  .rmh-invoice-card__header{display:grid;grid-template-columns:1fr;row-gap:0px;align-items:start;justify-items:stretch}
   .rmh-invoice-card__badge{display:none}
   .rmh-invoice-card__status-region{margin-top:0;width:100%}
   .rmh-invoice-card__status{padding:12px 18px;gap:12px;box-shadow:0 6px 18px rgba(36,50,95,.12)}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
- * Version:     2.4.26
+ * Version:     2.4.27
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.26';
+    public const PLUGIN_VERSION = '2.4.27';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- reduce the invoice card header row gap for large screens to eliminate extra vertical spacing
- set invoice item section headings to use zero margin
- bump the plugin version to 2.4.27

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfc5ea04d4832ca75931a4ae06e04a