### PR TITLE
Add automatic product image loader with legacy fallback toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.4.31
+- Nieuwe automatische productafbeelding-loader op basis van factuurnummer + orderregelindex (met retina `srcset` ondersteuning en 15-minuten caching).
+- Helperfuncties en filters toegevoegd voor paden en extensies (`rmh_productimg_bases`, `rmh_productimg_exts`, `rmh_productimg_enable_autoload`, `rmh_productimg_render_html`).
+- Admin-toggle én `RMH_DISABLE_LEGACY_IMAGES`-ondersteuning toegevoegd om legacy bijlagen als fallback uit te schakelen.
+- Legacy print.com orderregel-koppeling verwijderd; fallback gebruikt bestaande bijlagen of placeholders wanneer autoload niets vindt.

--- a/inc/helpers-productimg.php
+++ b/inc/helpers-productimg.php
@@ -1,0 +1,375 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('rmh_productimg_debug_log')) {
+    function rmh_productimg_debug_log(string $message): void {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('[RMH productimg] ' . $message);
+        }
+    }
+}
+
+if (!function_exists('rmh_productimg_normalize_path')) {
+    function rmh_productimg_normalize_path(string $path): string {
+        $normalized = wp_normalize_path($path);
+        if ($normalized === '') {
+            return '';
+        }
+        return rtrim($normalized, '/') . '/';
+    }
+}
+
+if (!function_exists('rmh_productimg_root_url')) {
+    function rmh_productimg_root_url(): string {
+        $candidates = [home_url(), site_url()];
+        foreach ($candidates as $candidate) {
+            $parts = wp_parse_url($candidate);
+            if (!is_array($parts) || empty($parts['host'])) {
+                continue;
+            }
+            $scheme = $parts['scheme'] ?? (is_ssl() ? 'https' : 'http');
+            $port   = isset($parts['port']) ? ':' . $parts['port'] : '';
+            return trailingslashit($scheme . '://' . $parts['host'] . $port);
+        }
+
+        return trailingslashit(home_url());
+    }
+}
+
+if (!function_exists('rmh_productimg_get_default_bases')) {
+    function rmh_productimg_get_default_bases(): array {
+        $bases = [];
+
+        if (defined('ABSPATH')) {
+            $path = rmh_productimg_normalize_path(trailingslashit(ABSPATH) . 'productimg');
+            $bases[$path] = [
+                'path'     => $path,
+                'url_base' => trailingslashit(site_url()) . 'productimg/',
+            ];
+        }
+
+        if (!empty($_SERVER['DOCUMENT_ROOT'])) {
+            $doc_root = rmh_productimg_normalize_path(rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\'));
+            if ($doc_root !== '') {
+                $path = rmh_productimg_normalize_path($doc_root . '/productimg');
+                $bases[$path] = [
+                    'path'     => $path,
+                    'url_base' => rmh_productimg_root_url() . 'productimg/',
+                ];
+            }
+        }
+
+        if (!function_exists('get_home_path') && defined('ABSPATH')) {
+            $file = trailingslashit(ABSPATH) . 'wp-admin/includes/file.php';
+            if (is_readable($file)) {
+                require_once $file;
+            }
+        }
+
+        if (function_exists('get_home_path')) {
+            $home_path = get_home_path();
+            if (is_string($home_path) && $home_path !== '') {
+                $path = rmh_productimg_normalize_path(trailingslashit($home_path) . 'productimg');
+                $bases[$path] = [
+                    'path'     => $path,
+                    'url_base' => trailingslashit(home_url()) . 'productimg/',
+                ];
+            }
+        }
+
+        return $bases;
+    }
+}
+
+if (!function_exists('rmh_productimg_get_bases')) {
+    function rmh_productimg_get_bases(): array {
+        $defaults = rmh_productimg_get_default_bases();
+        $default_paths = array_keys($defaults);
+
+        $filtered_paths = apply_filters('rmh_productimg_bases', $default_paths);
+        if (!is_array($filtered_paths)) {
+            $filtered_paths = $default_paths;
+        }
+
+        $bases = [];
+        foreach ($filtered_paths as $path) {
+            if (!is_string($path) || $path === '') {
+                continue;
+            }
+            $normalized = rmh_productimg_normalize_path($path);
+            if ($normalized === '') {
+                continue;
+            }
+            if (isset($bases[$normalized])) {
+                continue;
+            }
+            if (isset($defaults[$normalized])) {
+                $bases[$normalized] = $defaults[$normalized];
+                continue;
+            }
+            $bases[$normalized] = [
+                'path'     => $normalized,
+                'url_base' => trailingslashit(home_url()) . 'productimg/',
+            ];
+        }
+
+        return array_values($bases);
+    }
+}
+
+if (!function_exists('rmh_productimg_get_extensions')) {
+    function rmh_productimg_get_extensions(): array {
+        $extensions = ['png', 'jpg', 'jpeg', 'webp'];
+        $extensions = apply_filters('rmh_productimg_exts', $extensions);
+        if (!is_array($extensions)) {
+            $extensions = ['png', 'jpg', 'jpeg', 'webp'];
+        }
+
+        $normalized = [];
+        foreach ($extensions as $ext) {
+            if (!is_string($ext)) {
+                continue;
+            }
+            $ext = strtolower(trim($ext));
+            if ($ext === '') {
+                continue;
+            }
+            $normalized[$ext] = true;
+        }
+
+        return array_keys($normalized);
+    }
+}
+
+if (!function_exists('rmh_productimg_is_autoload_enabled')) {
+    function rmh_productimg_is_autoload_enabled(): bool {
+        $enabled = true;
+        $enabled = apply_filters('rmh_productimg_enable_autoload', $enabled);
+        return (bool) $enabled;
+    }
+}
+
+if (!function_exists('rmh_productimg_is_legacy_disabled')) {
+    function rmh_productimg_is_legacy_disabled(): bool {
+        if (defined('RMH_DISABLE_LEGACY_IMAGES')) {
+            return (bool) RMH_DISABLE_LEGACY_IMAGES;
+        }
+        return (bool) get_option('rmh_disable_legacy_images', 0);
+    }
+}
+
+if (!function_exists('rmh_productimg_normalize_invoice')) {
+    function rmh_productimg_normalize_invoice($invoiceNumber): string {
+        $invoiceNumber = is_string($invoiceNumber) ? trim($invoiceNumber) : '';
+        if ($invoiceNumber === '') {
+            return '';
+        }
+        $sanitized = preg_replace('/[^A-Za-z0-9_-]/', '', $invoiceNumber);
+        if (!is_string($sanitized)) {
+            return '';
+        }
+        return $sanitized;
+    }
+}
+
+if (!function_exists('rmh_productimg_cache_key')) {
+    function rmh_productimg_cache_key(string $invoice, int $lineIndex): string {
+        $key = strtolower($invoice) . '|' . $lineIndex;
+        return 'rmh_prodimg_' . md5($key);
+    }
+}
+
+if (!function_exists('rmh_productimg_collect_image_sizes')) {
+    function rmh_productimg_collect_image_sizes(string $path): array {
+        if (!is_readable($path)) {
+            return [];
+        }
+        $size = @getimagesize($path);
+        if (!is_array($size)) {
+            return [];
+        }
+        if (!isset($size[0], $size[1])) {
+            return [];
+        }
+        return ['width' => (int) $size[0], 'height' => (int) $size[1]];
+    }
+}
+
+if (!function_exists('rmh_productimg_find_image')) {
+    function rmh_productimg_find_image(string $invoice, int $lineIndex): ?array {
+        if ($invoice === '' || $lineIndex < 1) {
+            return null;
+        }
+        if (!rmh_productimg_is_autoload_enabled()) {
+            rmh_productimg_debug_log('Autoload uitgeschakeld via filter.');
+            return null;
+        }
+
+        $cache_key = rmh_productimg_cache_key($invoice, $lineIndex);
+        $cached = get_transient($cache_key);
+        if (is_array($cached)) {
+            if (!empty($cached['found'])) {
+                return $cached['data'];
+            }
+            return null;
+        }
+
+        $bases = rmh_productimg_get_bases();
+        $extensions = rmh_productimg_get_extensions();
+        $target = sprintf('%s-%d', $invoice, $lineIndex);
+
+        foreach ($bases as $base) {
+            $base_path = $base['path'];
+            $url_base  = $base['url_base'];
+
+            foreach ($extensions as $ext) {
+                $candidates = array_unique([$ext, strtoupper($ext), ucfirst($ext)]);
+                foreach ($candidates as $candidate_ext) {
+                    $filename = $target . '.' . $candidate_ext;
+                    $absolute = $base_path . $filename;
+                    rmh_productimg_debug_log('Probeer ' . $absolute);
+                    if (!is_readable($absolute) || !is_file($absolute)) {
+                        continue;
+                    }
+
+                    $info = rmh_productimg_collect_image_sizes($absolute);
+                    $variants = [
+                        [
+                            'url'    => $url_base . $filename,
+                            'path'   => $absolute,
+                            'width'  => $info['width'] ?? null,
+                            'height' => $info['height'] ?? null,
+                        ],
+                    ];
+
+                    $variant_suffixes = ['@2x', '-large'];
+                    foreach ($variant_suffixes as $suffix) {
+                        $variant_filename = $target . $suffix . '.' . $candidate_ext;
+                        $variant_path = $base_path . $variant_filename;
+                        rmh_productimg_debug_log('Zoek variant ' . $variant_path);
+                        if (!is_readable($variant_path) || !is_file($variant_path)) {
+                            continue;
+                        }
+                        $variant_info = rmh_productimg_collect_image_sizes($variant_path);
+                        $variants[] = [
+                            'url'    => $url_base . $variant_filename,
+                            'path'   => $variant_path,
+                            'width'  => $variant_info['width'] ?? null,
+                            'height' => $variant_info['height'] ?? null,
+                        ];
+                    }
+
+                    $srcset_parts = [];
+                    $max_width = 0;
+                    foreach ($variants as $variant) {
+                        if (!empty($variant['width'])) {
+                            $descriptor = $variant['width'] . 'w';
+                            $max_width = max($max_width, (int) $variant['width']);
+                        } else {
+                            $descriptor = '1x';
+                        }
+                        $srcset_parts[] = esc_url_raw($variant['url']) . ' ' . $descriptor;
+                    }
+
+                    $result = [
+                        'url'    => $variants[0]['url'],
+                        'path'   => $variants[0]['path'],
+                        'width'  => $variants[0]['width'] ?? null,
+                        'height' => $variants[0]['height'] ?? null,
+                    ];
+
+                    if (count($variants) > 1) {
+                        $result['srcset'] = implode(', ', $srcset_parts);
+                        if ($max_width > 0) {
+                            $result['sizes'] = sprintf('(max-width: %1$dpx) 100vw, %1$dpx', $max_width);
+                        } else {
+                            $result['sizes'] = '100vw';
+                        }
+                    }
+
+                    set_transient($cache_key, ['found' => true, 'data' => $result], 15 * MINUTE_IN_SECONDS);
+                    rmh_productimg_debug_log('Gevonden: ' . $absolute);
+
+                    return $result;
+                }
+            }
+        }
+
+        set_transient($cache_key, ['found' => false], 15 * MINUTE_IN_SECONDS);
+        rmh_productimg_debug_log('Geen afbeelding gevonden voor ' . $target);
+
+        return null;
+    }
+}
+
+if (!function_exists('rmh_render_orderline_image')) {
+    function rmh_render_orderline_image($invoiceNumber, $lineIndex, array $args = []): string {
+        $invoice = rmh_productimg_normalize_invoice($invoiceNumber);
+        $line    = (int) $lineIndex;
+
+        $defaults = [
+            'legacy_html'      => '',
+            'placeholder_html' => '',
+        ];
+        $args = array_merge($defaults, $args);
+
+        $image = null;
+        if ($invoice !== '' && $line >= 1) {
+            $image = rmh_productimg_find_image($invoice, $line);
+        }
+
+        if ($image) {
+            $alt = sprintf(
+                /* translators: 1: invoice number, 2: line index */
+                __('Productafbeelding factuur %1$s – regel %2$d', 'printcom-order-tracker'),
+                $invoice,
+                $line
+            );
+            $attributes = [
+                'src'      => $image['url'],
+                'alt'      => $alt,
+                'loading'  => 'lazy',
+                'decoding' => 'async',
+                'class'    => 'rmh-ot__image rmh-orderline-image__img',
+            ];
+            if (!empty($image['srcset'])) {
+                $attributes['srcset'] = $image['srcset'];
+            }
+            if (!empty($image['sizes'])) {
+                $attributes['sizes'] = $image['sizes'];
+            }
+            if (!empty($image['width'])) {
+                $attributes['width'] = (int) $image['width'];
+            }
+            if (!empty($image['height'])) {
+                $attributes['height'] = (int) $image['height'];
+            }
+
+            $parts = [];
+            foreach ($attributes as $key => $value) {
+                if (($value === '' || $value === null) && $key !== 'width' && $key !== 'height') {
+                    continue;
+                }
+                if ($key === 'src') {
+                    $value = esc_url($value);
+                } elseif ($key === 'width' || $key === 'height') {
+                    $value = esc_attr((string) $value);
+                } else {
+                    $value = esc_attr($value);
+                }
+                $parts[] = sprintf('%s="%s"', $key, $value);
+            }
+            $img_html = '<img ' . implode(' ', $parts) . ' />';
+        } elseif (!rmh_productimg_is_legacy_disabled() && $args['legacy_html'] !== '') {
+            $img_html = $args['legacy_html'];
+        } else {
+            $img_html = $args['placeholder_html'];
+        }
+
+        $figure = sprintf('<figure class="rmh-orderline-image">%s</figure>', $img_html);
+
+        return apply_filters('rmh_productimg_render_html', $figure, $invoice, $line, $args);
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Tokens worden automatisch vernieuwd. Ontworpen om goed samen te werken met **Div
 - Zoekformulier op ordernummer + postcode via shortcode [print_order_lookup]
 - Cache instelbaar (default 30 minuten)
 - Ondersteuning voor eigen afbeelding per orderpagina
-- Automatische productafbeeldingen vanuit `/productimg/` op basis van factuurnummer (ook bij WordPress-installaties in een submap)
+- Automatische productafbeeldingen vanuit `/productimg/` op basis van factuurnummer en regelnummers (met fallback op legacy bijlagen en placeholders)
 - Tokens worden automatisch vernieuwd
 
 ## Gebruik
@@ -32,6 +32,19 @@ Tokens worden automatisch vernieuwd. Ontworpen om goed samen te werken met **Div
 - Nieuwe pagina’s worden onder `/bestellingen/` geplaatst en automatisch ingesteld op het Divi full-width template zonder zijbalk.
 - In het metabox **Productfoto’s (per item)** kun je per orderItemNumber een eigen afbeelding koppelen die op de statuspagina verschijnt.
 - Verwijder je een order, dan wist de plugin ook de gekoppelde pagina, cache en statusgegevens.
+
+### Productafbeeldingen
+- De plugin zoekt automatisch naar bestandsnamen in het formaat `{factuurnummer}-{regelindex}.{ext}` waarbij de regelindex 1-based is (dus de eerste regel gebruikt `-1`).
+- Ondersteunde extensies zijn `png`, `jpg`, `jpeg` en `webp` (hoofd-/kleine letters zijn toegestaan). Varianten met `@2x` of `-large` worden automatisch aan `srcset` en `sizes` toegevoegd voor scherpe retina-beelden.
+- Zoekvolgorde voor afbeeldingen:
+  1. `ABSPATH . 'productimg'`
+  2. `$_SERVER['DOCUMENT_ROOT'] . '/productimg'`
+  3. `home_path() . 'productimg'`
+  De eerste leesbare match wordt gebruikt; paden kunnen worden uitgebreid via de filter `rmh_productimg_bases`.
+- Vind je meerdere varianten, dan genereert de plugin nette HTML: `<figure class="rmh-orderline-image"><img ... /></figure>` met `loading="lazy"` en `decoding="async"`.
+- Wanneer er geen bestand wordt gevonden, valt de weergave terug op legacy bijlagen en daarna op de ingebouwde placeholder, tenzij legacy expliciet is uitgeschakeld.
+- Legacy fallback uitschakelen kan via de optie **Legacy afbeeldingkoppeling uitschakelen** op de instellingenpagina of door `define('RMH_DISABLE_LEGACY_IMAGES', true);` in `wp-config.php` te plaatsen (de constante heeft voorrang).
+- Resultaten van zoekacties worden 15 minuten gecachet in transients om schijf-hits te beperken. Extra filters: `rmh_productimg_exts`, `rmh_productimg_enable_autoload` en `rmh_productimg_render_html` voor geavanceerde aanpassingen.
 
 ### Cache & tokens
 - API-resultaten worden als transient opgeslagen. Actieve orders worden standaard 5 minuten gecachet; afgeronde orders blijven 24 uur warm voor snelle laadtijden.


### PR DESCRIPTION
## Summary
- add a helper that resolves `/productimg/` assets per factuurnummer + regelindex inclusief caching, retina varianten en nieuwe filters
- render orderregel-afbeeldingen via de helper met figure-markup, legacy/placeholder fallback en een beheersbare legacy toggle
- documenteer het nieuwe gedrag (README/CHANGELOG) en verhoog de pluginversie

## Testing
- php -l inc/helpers-productimg.php
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68d10e1c898c832cb0529d6cd72f652c