### PR TITLE
Add product image debug tools and cache buster support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.32
+- Fix: URL-base met `home_url()` voor submap-installaties.
+- Feat: Debugtools — shortcode `[rmh_test_image]`, admin testpagina en WP-CLI commando `wp rmh img-test`.
+- Feat: Cache-buster via `RMH_IMG_CACHE_BUSTER` en configureerbare TTL’s voor hits/misses.
+- Chore: Legacy volgorde afgedwongen en print.com-orderregel fallback uitgeschakeld ten gunste van factuurnummer + index.
+
 ## 2.4.31
 - Nieuwe automatische productafbeelding-loader op basis van factuurnummer + orderregelindex (met retina `srcset` ondersteuning en 15-minuten caching).
 - Helperfuncties en filters toegevoegd voor paden en extensies (`rmh_productimg_bases`, `rmh_productimg_exts`, `rmh_productimg_enable_autoload`, `rmh_productimg_render_html`).

--- a/inc/admin-test-page.php
+++ b/inc/admin-test-page.php
@@ -1,0 +1,129 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('rmh_productimg_register_admin_test_page')) {
+    add_action('admin_menu', 'rmh_productimg_register_admin_test_page');
+
+    /**
+     * Register the Productimg test page under the Settings menu.
+     */
+    function rmh_productimg_register_admin_test_page(): void {
+        add_options_page(
+            __('RMH Productimg Test', 'printcom-order-tracker'),
+            __('RMH Productimg Test', 'printcom-order-tracker'),
+            'manage_options',
+            'rmh-productimg-test',
+            'rmh_productimg_render_admin_test_page'
+        );
+    }
+}
+
+if (!function_exists('rmh_productimg_render_admin_test_page')) {
+    /**
+     * Render the admin test page for the automatic product image resolver.
+     */
+    function rmh_productimg_render_admin_test_page(): void {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Je hebt geen rechten om deze pagina te bekijken.', 'printcom-order-tracker'));
+        }
+
+        $invoice_input = '';
+        $invoice       = '';
+        $index_input   = 1;
+        $result        = null;
+        $error_message = '';
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            check_admin_referer('rmh_productimg_test_action', 'rmh_productimg_test_nonce');
+
+            if (isset($_POST['rmh_productimg_invoice'])) {
+                $invoice_input = sanitize_text_field(wp_unslash((string) $_POST['rmh_productimg_invoice']));
+                $invoice       = rmh_productimg_normalize_invoice($invoice_input);
+            }
+
+            if (isset($_POST['rmh_productimg_index'])) {
+                $index_input = (int) wp_unslash((string) $_POST['rmh_productimg_index']);
+                if ($index_input < 1) {
+                    $index_input = 1;
+                }
+            }
+
+            if ($invoice === '') {
+                $error_message = esc_html__('Factuurnummer is verplicht. Gebruik het exacte nummer uit Invoice Ninja.', 'printcom-order-tracker');
+            } elseif (!function_exists('rmh_resolve_orderline_image')) {
+                $error_message = esc_html__('Resolver niet beschikbaar.', 'printcom-order-tracker');
+            } else {
+                $result = rmh_resolve_orderline_image($invoice, $index_input);
+                if (!$result) {
+                    $error_message = sprintf(
+                        esc_html__('Geen bestand gevonden voor %1$s-%2$d. Controleer naam, extensie, rechten en cache-buster (RMH_IMG_CACHE_BUSTER).', 'printcom-order-tracker'),
+                        $invoice,
+                        $index_input
+                    );
+                }
+            }
+        }
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('RMH Productimg Test', 'printcom-order-tracker') . '</h1>';
+        echo '<p>' . esc_html__('Test de automatische productafbeelding op basis van factuurnummer en 1-based regelindex. Bestanden moeten in /productimg/ staan en heten {factuurnummer}-{index}.{ext}.', 'printcom-order-tracker') . '</p>';
+
+        echo '<form method="post">';
+        wp_nonce_field('rmh_productimg_test_action', 'rmh_productimg_test_nonce');
+        echo '<table class="form-table" role="presentation">';
+        echo '<tbody>';
+        echo '<tr>';
+        echo '<th scope="row"><label for="rmh_productimg_invoice">' . esc_html__('Factuurnummer', 'printcom-order-tracker') . '</label></th>';
+        echo '<td><input type="text" class="regular-text" id="rmh_productimg_invoice" name="rmh_productimg_invoice" value="' . esc_attr($invoice_input) . '" required /></td>';
+        echo '</tr>';
+        echo '<tr>';
+        echo '<th scope="row"><label for="rmh_productimg_index">' . esc_html__('Regelindex (1-based)', 'printcom-order-tracker') . '</label></th>';
+        echo '<td><input type="number" min="1" class="small-text" id="rmh_productimg_index" name="rmh_productimg_index" value="' . esc_attr((string) $index_input) . '" required /></td>';
+        echo '</tr>';
+        echo '</tbody>';
+        echo '</table>';
+        submit_button(esc_html__('Test resolver', 'printcom-order-tracker'));
+        echo '</form>';
+
+        if ($error_message !== '') {
+            echo '<div class="notice notice-warning"><p>' . $error_message . '</p></div>';
+        } elseif ($result) {
+            echo '<h2>' . esc_html__('Resultaat', 'printcom-order-tracker') . '</h2>';
+            echo '<p><strong>' . esc_html__('Bestandspad', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($result['path']) . '</code></p>';
+            echo '<p><strong>' . esc_html__('URL', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($result['url']) . '</code></p>';
+
+            $img_attrs = [
+                'src'      => esc_url($result['url']),
+                'alt'      => sprintf(esc_attr__('Testafbeelding voor %1$s regel %2$d', 'printcom-order-tracker'), $invoice ?: $invoice_input, $index_input),
+                'loading'  => 'lazy',
+                'decoding' => 'async',
+                'style'    => 'max-width:100%;height:auto;display:block;margin-top:8px;',
+            ];
+            if (!empty($result['srcset'])) {
+                $img_attrs['srcset'] = esc_attr($result['srcset']);
+            }
+            if (!empty($result['sizes'])) {
+                $img_attrs['sizes'] = esc_attr($result['sizes']);
+            }
+            if (!empty($result['width'])) {
+                $img_attrs['width'] = (int) $result['width'];
+            }
+            if (!empty($result['height'])) {
+                $img_attrs['height'] = (int) $result['height'];
+            }
+
+            $pairs = [];
+            foreach ($img_attrs as $key => $value) {
+                if ($value === '' || $value === null) {
+                    continue;
+                }
+                $pairs[] = sprintf('%s="%s"', $key, $value);
+            }
+            echo '<p><img ' . implode(' ', $pairs) . ' /></p>';
+        }
+
+        echo '</div>';
+    }
+}

--- a/inc/cli-commands.php
+++ b/inc/cli-commands.php
@@ -1,0 +1,69 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('RMH_Productimg_CLI_Command')) {
+    /**
+     * WP-CLI helpers for RMH automatic product images.
+     */
+    class RMH_Productimg_CLI_Command {
+        /**
+         * Test de automatische productafbeeldingsresolver voor een factuur en regelindex.
+         *
+         * ## OPTIONS
+         *
+         * <invoice>
+         * : Het factuurnummer (bijv. RMH-0021).
+         *
+         * [<index>]
+         * : De 1-based regelindex (default: 1).
+         *
+         * ## EXAMPLES
+         *
+         *     wp rmh img-test RMH-0021 1
+         *
+         * @when after_wp_load
+         */
+        public function __invoke(array $args, array $assoc_args): void {
+            if (!class_exists('WP_CLI')) {
+                return;
+            }
+
+            $invoice_input = $args[0] ?? '';
+            if (!is_string($invoice_input) || $invoice_input === '') {
+                WP_CLI::error('Factuurnummer is verplicht.');
+            }
+
+            $index_arg = $args[1] ?? '1';
+            $index     = is_numeric($index_arg) ? (int) $index_arg : 1;
+            if ($index < 1) {
+                WP_CLI::error('Index moet minimaal 1 zijn.');
+            }
+
+            $invoice = rmh_productimg_normalize_invoice($invoice_input);
+            if ($invoice === '') {
+                WP_CLI::error('Factuurnummer ongeldig na normalisatie. Controleer het invoerformaat.');
+            }
+
+            if (!function_exists('rmh_resolve_orderline_image')) {
+                WP_CLI::error('Resolver niet beschikbaar.');
+            }
+
+            $result = rmh_resolve_orderline_image($invoice, $index);
+            if ($result) {
+                WP_CLI::log('FS: ' . $result['path']);
+                WP_CLI::log('URL: ' . $result['url']);
+                WP_CLI::success('Afbeelding gevonden.');
+                return;
+            }
+
+            WP_CLI::warning('Geen bestand gevonden. Controleer naam, extensie, rechten of stel tijdelijk RMH_IMG_CACHE_BUSTER in.');
+            WP_CLI::halt(1);
+        }
+    }
+}
+
+if (class_exists('WP_CLI')) {
+    WP_CLI::add_command('rmh img-test', 'RMH_Productimg_CLI_Command');
+}

--- a/inc/debug-shortcode.php
+++ b/inc/debug-shortcode.php
@@ -1,0 +1,102 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('rmh_productimg_register_debug_shortcode')) {
+    /**
+     * Register the debug shortcode for testing automatic product images.
+     */
+    function rmh_productimg_register_debug_shortcode(): void {
+        add_shortcode('rmh_test_image', 'rmh_productimg_render_debug_shortcode');
+    }
+    add_action('init', 'rmh_productimg_register_debug_shortcode');
+}
+
+if (!function_exists('rmh_productimg_render_debug_shortcode')) {
+    /**
+     * Render output for the [rmh_test_image] shortcode.
+     *
+     * @param array<string,mixed> $atts Shortcode attributes.
+     */
+    function rmh_productimg_render_debug_shortcode($atts): string {
+        if (!function_exists('current_user_can') || !current_user_can('manage_options')) {
+            $enabled = apply_filters('rmh_enable_debug_shortcodes', false);
+            if (!$enabled) {
+                return '<code>' . esc_html__('Debugshortcode uitgeschakeld.', 'printcom-order-tracker') . '</code>';
+            }
+        }
+
+        $atts = shortcode_atts(
+            [
+                'invoice' => '',
+                'index'   => '1',
+            ],
+            $atts,
+            'rmh_test_image'
+        );
+
+        $invoice_raw = is_string($atts['invoice']) ? $atts['invoice'] : '';
+        $index_raw   = is_string($atts['index']) || is_numeric($atts['index']) ? (string) $atts['index'] : '1';
+
+        $invoice = rmh_productimg_normalize_invoice($invoice_raw);
+        $line    = (int) $index_raw;
+        if ($line < 1) {
+            $line = 1;
+        }
+
+        if ($invoice === '') {
+            return '<code>' . esc_html__('Geef een factuurnummer op via invoice="...".', 'printcom-order-tracker') . '</code>';
+        }
+        if (!function_exists('rmh_resolve_orderline_image')) {
+            return '<code>' . esc_html__('Resolver niet beschikbaar.', 'printcom-order-tracker') . '</code>';
+        }
+
+        $result = rmh_resolve_orderline_image($invoice, $line);
+        if (!$result) {
+            $message = sprintf(
+                esc_html__('Geen bestand gevonden. Controleer naam (%1$s-%2$d.{ext}), 1-based index, extensie, rechten of stel tijdelijk RMH_IMG_CACHE_BUSTER in.', 'printcom-order-tracker'),
+                $invoice,
+                $line
+            );
+            return '<code>' . $message . '</code>';
+        }
+
+        $output  = '<div class="rmh-productimg-debug">';
+        $output .= '<p><strong>' . esc_html__('Bestandspad', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($result['path']) . '</code></p>';
+        $output .= '<p><strong>' . esc_html__('URL', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($result['url']) . '</code></p>';
+
+        $img_attrs = [
+            'src'      => esc_url($result['url']),
+            'alt'      => sprintf(esc_attr__('Debugvoorbeeld voor %1$s regel %2$d', 'printcom-order-tracker'), $invoice, $line),
+            'loading'  => 'lazy',
+            'decoding' => 'async',
+            'style'    => 'max-width:100%;height:auto;display:block;margin-top:8px;',
+        ];
+
+        if (!empty($result['srcset'])) {
+            $img_attrs['srcset'] = esc_attr($result['srcset']);
+        }
+        if (!empty($result['sizes'])) {
+            $img_attrs['sizes'] = esc_attr($result['sizes']);
+        }
+        if (!empty($result['width'])) {
+            $img_attrs['width'] = (int) $result['width'];
+        }
+        if (!empty($result['height'])) {
+            $img_attrs['height'] = (int) $result['height'];
+        }
+
+        $attr_pairs = [];
+        foreach ($img_attrs as $key => $value) {
+            if ($value === '' || $value === null) {
+                continue;
+            }
+            $attr_pairs[] = sprintf('%s="%s"', $key, $value);
+        }
+        $output .= '<p><img ' . implode(' ', $attr_pairs) . ' /></p>';
+        $output .= '</div>';
+
+        return $output;
+    }
+}

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
 
- * Version:     2.4.31
+ * Version:     2.4.32
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -14,8 +14,25 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 require_once plugin_dir_path(__FILE__) . 'inc/helpers-productimg.php';
 
+if (is_admin()) {
+    require_once plugin_dir_path(__FILE__) . 'inc/admin-test-page.php';
+}
+
+$load_debug_shortcode = false;
+if (function_exists('current_user_can') && current_user_can('manage_options')) {
+    $load_debug_shortcode = true;
+}
+$load_debug_shortcode = apply_filters('rmh_enable_debug_shortcodes', $load_debug_shortcode);
+if ($load_debug_shortcode) {
+    require_once plugin_dir_path(__FILE__) . 'inc/debug-shortcode.php';
+}
+
+if (defined('WP_CLI') && WP_CLI) {
+    require_once plugin_dir_path(__FILE__) . 'inc/cli-commands.php';
+}
+
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.31';
+    public const PLUGIN_VERSION = '2.4.32';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';


### PR DESCRIPTION
## Summary
- ensure automatic product image URLs use `home_url()` and include cache-buster aware keys with configurable TTLs
- add a resolver helper plus shortcode, admin test page, and WP-CLI command to debug invoice/line image lookups
- conditionally load the new debug utilities, bump the plugin version to 2.4.32, and document the workflow updates

## Testing
- php -l inc/helpers-productimg.php
- php -l inc/debug-shortcode.php
- php -l inc/admin-test-page.php
- php -l inc/cli-commands.php
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68d117a48e80832c98e0238ef1e113c3