### PR TITLE
Improve automatic product image diagnostics and rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.4.34
+- Fix: orderpagina toont opnieuw automatische productafbeeldingen met 1-based indexering.
+- Fix: URL-base overal via `home_url()` met controle op DOCUMENT_ROOT naar `https://rikkermediahub.com/productimg/`.
+- Feat: uitgebreide diagnose in admin inclusief pad/URL per basis, cache-details en cache-buster knop.
+- DX: HTML-debugcomment op orderregels bij `WP_DEBUG` voor snelle analyse van hits/misses.
+- Safe: extra WordPress-guards voor includes, capabilities en context.
+
 ## 2.4.33
 - Confirmed compatibility with WordPress 6.8.2 and PHP 8.3.
 

--- a/inc/admin-test-page.php
+++ b/inc/admin-test-page.php
@@ -3,6 +3,14 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!is_admin()) {
+    return;
+}
+
+if (function_exists('current_user_can') && !current_user_can('manage_options')) {
+    return;
+}
+
 if (!function_exists('rmh_productimg_register_admin_test_page')) {
     add_action('admin_menu', 'rmh_productimg_register_admin_test_page');
 
@@ -34,44 +42,91 @@ if (!function_exists('rmh_productimg_render_admin_test_page')) {
         $index_input   = 1;
         $result        = null;
         $error_message = '';
+        $messages      = [];
+        $debug_details = [];
+
+        $cache_buster_value = rmh_productimg_get_cache_buster_option();
+        $cache_salt         = rmh_productimg_get_cache_salt();
+
+        $action = 'test';
+        if (!empty($_SERVER['REQUEST_METHOD'])) {
+            $action = isset($_POST['rmh_productimg_action']) ? sanitize_text_field(wp_unslash((string) $_POST['rmh_productimg_action'])) : 'test';
+        }
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            check_admin_referer('rmh_productimg_test_action', 'rmh_productimg_test_nonce');
+            if ($action === 'bump_cache') {
+                check_admin_referer('rmh_productimg_bump_cache_action', 'rmh_productimg_bump_cache_nonce');
 
-            if (isset($_POST['rmh_productimg_invoice'])) {
-                $invoice_input = sanitize_text_field(wp_unslash((string) $_POST['rmh_productimg_invoice']));
-                $invoice       = rmh_productimg_normalize_invoice($invoice_input);
-            }
+                $current_value = rmh_productimg_get_cache_buster_option();
+                $current_int   = is_numeric($current_value) ? (int) $current_value : 0;
+                $next_int      = $current_int + 1;
+                update_option('rmh_img_cache_buster', (string) $next_int);
 
-            if (isset($_POST['rmh_productimg_index'])) {
-                $index_input = (int) wp_unslash((string) $_POST['rmh_productimg_index']);
-                if ($index_input < 1) {
-                    $index_input = 1;
-                }
-            }
-
-            if ($invoice === '') {
-                $error_message = esc_html__('Factuurnummer is verplicht. Gebruik het exacte nummer uit Invoice Ninja.', 'printcom-order-tracker');
-            } elseif (!function_exists('rmh_resolve_orderline_image')) {
-                $error_message = esc_html__('Resolver niet beschikbaar.', 'printcom-order-tracker');
+                $cache_buster_value = rmh_productimg_get_cache_buster_option();
+                $cache_salt         = rmh_productimg_get_cache_salt();
+                $messages[] = sprintf(
+                    __('Cache buster verhoogd naar %s.', 'printcom-order-tracker'),
+                    $cache_buster_value !== '' ? $cache_buster_value : __('(leeg)', 'printcom-order-tracker')
+                );
             } else {
-                $result = rmh_resolve_orderline_image($invoice, $index_input);
-                if (!$result) {
-                    $error_message = sprintf(
-                        esc_html__('Geen bestand gevonden voor %1$s-%2$d. Controleer naam, extensie, rechten en cache-buster (RMH_IMG_CACHE_BUSTER).', 'printcom-order-tracker'),
-                        $invoice,
-                        $index_input
-                    );
+                check_admin_referer('rmh_productimg_test_action', 'rmh_productimg_test_nonce');
+
+                if (isset($_POST['rmh_productimg_invoice'])) {
+                    $invoice_input = sanitize_text_field(wp_unslash((string) $_POST['rmh_productimg_invoice']));
+                    $invoice       = rmh_productimg_normalize_invoice($invoice_input);
+                }
+
+                if (isset($_POST['rmh_productimg_index'])) {
+                    $index_input = (int) wp_unslash((string) $_POST['rmh_productimg_index']);
+                    if ($index_input < 1) {
+                        $index_input = 1;
+                    }
+                }
+
+                if ($invoice === '') {
+                    $error_message = esc_html__('Factuurnummer is verplicht. Gebruik het exacte nummer uit Invoice Ninja.', 'printcom-order-tracker');
+                } elseif (!function_exists('rmh_resolve_orderline_image')) {
+                    $error_message = esc_html__('Resolver niet beschikbaar.', 'printcom-order-tracker');
+                } else {
+                    $result        = rmh_resolve_orderline_image($invoice_input, $index_input);
+                    $debug_details = rmh_productimg_get_last_debug();
+
+                    if (!$result) {
+                        $error_message = sprintf(
+                            esc_html__('Geen bestand gevonden voor %1$s-%2$d. Controleer naam, extensie, rechten en de cache-buster (knop hieronder of optie rmh_img_cache_buster).', 'printcom-order-tracker'),
+                            $invoice,
+                            $index_input
+                        );
+                    }
                 }
             }
+        }
+
+        $minute = (defined('MINUTE_IN_SECONDS') && MINUTE_IN_SECONDS > 0) ? (int) MINUTE_IN_SECONDS : 60;
+        $ttl_hit = defined('RMH_IMG_CACHE_TTL_HIT') ? (int) RMH_IMG_CACHE_TTL_HIT : 15 * $minute;
+        $ttl_miss = defined('RMH_IMG_CACHE_TTL_MISS') ? (int) RMH_IMG_CACHE_TTL_MISS : 5 * $minute;
+        $ttl_hit_minutes = $minute > 0 ? round($ttl_hit / $minute, 1) : $ttl_hit;
+        $ttl_miss_minutes = $minute > 0 ? round($ttl_miss / $minute, 1) : $ttl_miss;
+
+        $docroot_example = null;
+        foreach (rmh_productimg_get_default_bases() as $base) {
+            if (($base['source'] ?? '') !== 'DOCUMENT_ROOT') {
+                continue;
+            }
+            $docroot_example = [
+                'path' => $base['path'] . 'RMH-0021-3.png',
+                'url'  => $base['url_base'] . 'RMH-0021-3.png',
+            ];
+            break;
         }
 
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('RMH Productimg Test', 'printcom-order-tracker') . '</h1>';
         echo '<p>' . esc_html__('Test de automatische productafbeelding op basis van factuurnummer en 1-based regelindex. Bestanden moeten in /productimg/ staan en heten {factuurnummer}-{index}.{ext}.', 'printcom-order-tracker') . '</p>';
 
-        echo '<form method="post">';
+        echo '<form method="post" class="rmh-productimg-test-form">';
         wp_nonce_field('rmh_productimg_test_action', 'rmh_productimg_test_nonce');
+        echo '<input type="hidden" name="rmh_productimg_action" value="test" />';
         echo '<table class="form-table" role="presentation">';
         echo '<tbody>';
         echo '<tr>';
@@ -87,9 +142,28 @@ if (!function_exists('rmh_productimg_render_admin_test_page')) {
         submit_button(esc_html__('Test resolver', 'printcom-order-tracker'));
         echo '</form>';
 
+        echo '<div class="rmh-productimg-cache-tools">';
+        echo '<h2>' . esc_html__('Diagnose & cache', 'printcom-order-tracker') . '</h2>';
+        echo '<p><strong>' . esc_html__('Cache-buster waarde', 'printcom-order-tracker') . ':</strong> <code>' . ($cache_buster_value !== '' ? esc_html($cache_buster_value) : esc_html__('(leeg)', 'printcom-order-tracker')) . '</code></p>';
+        echo '<p><strong>' . esc_html__('Cache-salt', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($cache_salt !== '' ? $cache_salt : __('(leeg)', 'printcom-order-tracker')) . '</code></p>';
+        echo '<p><strong>' . esc_html__('TTL hit', 'printcom-order-tracker') . ':</strong> ' . esc_html($ttl_hit) . 's (~' . esc_html($ttl_hit_minutes) . 'm)</p>';
+        echo '<p><strong>' . esc_html__('TTL miss', 'printcom-order-tracker') . ':</strong> ' . esc_html($ttl_miss) . 's (~' . esc_html($ttl_miss_minutes) . 'm)</p>';
+        echo '<form method="post" class="rmh-productimg-cache-bump">';
+        wp_nonce_field('rmh_productimg_bump_cache_action', 'rmh_productimg_bump_cache_nonce');
+        echo '<input type="hidden" name="rmh_productimg_action" value="bump_cache" />';
+        submit_button(esc_html__('Cache buster verhogen', 'printcom-order-tracker'), 'secondary', 'rmh_productimg_bump_cache', false);
+        echo '</form>';
+        echo '</div>';
+
+        foreach ($messages as $message) {
+            echo '<div class="notice notice-success"><p>' . esc_html($message) . '</p></div>';
+        }
+
         if ($error_message !== '') {
-            echo '<div class="notice notice-warning"><p>' . $error_message . '</p></div>';
-        } elseif ($result) {
+            echo '<div class="notice notice-warning"><p>' . esc_html($error_message) . '</p></div>';
+        }
+
+        if ($result) {
             echo '<h2>' . esc_html__('Resultaat', 'printcom-order-tracker') . '</h2>';
             echo '<p><strong>' . esc_html__('Bestandspad', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($result['path']) . '</code></p>';
             echo '<p><strong>' . esc_html__('URL', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($result['url']) . '</code></p>';
@@ -122,6 +196,71 @@ if (!function_exists('rmh_productimg_render_admin_test_page')) {
                 $pairs[] = sprintf('%s="%s"', $key, $value);
             }
             echo '<p><img ' . implode(' ', $pairs) . ' /></p>';
+        }
+
+        if (!empty($debug_details)) {
+            echo '<h2>' . esc_html__('Diagnoserapport', 'printcom-order-tracker') . '</h2>';
+            echo '<p><strong>' . esc_html__('Invoer', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($debug_details['raw_invoice'] ?? $invoice_input) . '</code> → <code>' . esc_html($debug_details['target'] ?? '') . '</code></p>';
+            echo '<p><strong>' . esc_html__('Legacy fallback toegestaan', 'printcom-order-tracker') . ':</strong> ' . (!empty($debug_details['legacy_allowed']) ? esc_html__('ja', 'printcom-order-tracker') : esc_html__('nee', 'printcom-order-tracker')) . '</p>';
+            if (!empty($debug_details['hit']['path'])) {
+                echo '<p><strong>' . esc_html__('Hit', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($debug_details['hit']['path']) . '</code> → <code>' . esc_html($debug_details['hit']['url']) . '</code></p>';
+            } else {
+                echo '<p><strong>' . esc_html__('Hit', 'printcom-order-tracker') . ':</strong> ' . esc_html__('geen, fallback actief', 'printcom-order-tracker') . '</p>';
+            }
+            if (!empty($debug_details['skipped'])) {
+                echo '<p><strong>' . esc_html__('Skips', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($debug_details['skipped']) . '</code></p>';
+            }
+
+            echo '<p><strong>' . esc_html__('Cache-key', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($debug_details['cache']['key'] ?? '') . '</code> (';
+            if (!empty($debug_details['cache']['from_cache'])) {
+                echo esc_html__('uit cache', 'printcom-order-tracker');
+            } elseif (!empty($debug_details['cache']['stored'])) {
+                $stored_state = (string) $debug_details['cache']['stored'];
+                echo esc_html(sprintf(__('nieuw: %s', 'printcom-order-tracker'), $stored_state));
+            } else {
+                echo esc_html__('lookup', 'printcom-order-tracker');
+            }
+            echo ')</p>';
+
+            if (!empty($debug_details['bases'])) {
+                echo '<div class="rmh-productimg-base-details">';
+                foreach ($debug_details['bases'] as $base) {
+                    $source_label = $base['source'] ?? '';
+                    if (!is_string($source_label) || $source_label === '') {
+                        $source_label = esc_html__('custom', 'printcom-order-tracker');
+                    }
+                    $summary = sprintf(
+                        __('Basis %1$s — %2$s', 'printcom-order-tracker'),
+                        $source_label,
+                        $base['path'] ?? ''
+                    );
+                    echo '<details>';
+                    echo '<summary>' . esc_html($summary) . '</summary>';
+                    echo '<p><strong>' . esc_html__('Pad', 'printcom-order-tracker') . ':</strong> <code>' . esc_html((string) ($base['path'] ?? '')) . '</code></p>';
+                    echo '<p><strong>' . esc_html__('URL-base', 'printcom-order-tracker') . ':</strong> <code>' . esc_html((string) ($base['url_base'] ?? '')) . '</code></p>';
+                    if (!empty($base['candidates'])) {
+                        echo '<ul>';
+                        foreach ($base['candidates'] as $candidate) {
+                            $label = (string) ($candidate['path'] ?? '');
+                            $status_text = !empty($candidate['hit']) ? __('gevonden', 'printcom-order-tracker') : __('niet gevonden', 'printcom-order-tracker');
+                            if (!empty($candidate['variant'])) {
+                                $variant_text = sprintf(__('variant %s', 'printcom-order-tracker'), (string) $candidate['variant']);
+                                $status_text .= ' (' . $variant_text . ')';
+                            }
+                            echo '<li><code>' . esc_html($label) . '</code> – ' . esc_html($status_text) . '</li>';
+                        }
+                        echo '</ul>';
+                    }
+                    echo '</details>';
+                }
+                echo '</div>';
+            }
+        }
+
+        if ($docroot_example) {
+            echo '<h2>' . esc_html__('Self-check DOCROOT', 'printcom-order-tracker') . '</h2>';
+            echo '<p><strong>' . esc_html__('Voorbeeldpad', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($docroot_example['path']) . '</code></p>';
+            echo '<p><strong>' . esc_html__('Voorbeeld-URL', 'printcom-order-tracker') . ':</strong> <code>' . esc_html($docroot_example['url']) . '</code></p>';
         }
 
         echo '</div>';

--- a/inc/cli-commands.php
+++ b/inc/cli-commands.php
@@ -58,7 +58,7 @@ if (!class_exists('RMH_Productimg_CLI_Command')) {
                 return;
             }
 
-            WP_CLI::warning('Geen bestand gevonden. Controleer naam, extensie, rechten of stel tijdelijk RMH_IMG_CACHE_BUSTER in.');
+            WP_CLI::warning('Geen bestand gevonden. Controleer naam, extensie, rechten of verhoog tijdelijk de cache-buster (optie rmh_img_cache_buster, admin-knop of constante RMH_IMG_CACHE_BUSTER).');
             WP_CLI::halt(1);
         }
     }

--- a/inc/debug-shortcode.php
+++ b/inc/debug-shortcode.php
@@ -55,7 +55,7 @@ if (!function_exists('rmh_productimg_render_debug_shortcode')) {
         $result = rmh_resolve_orderline_image($invoice, $line);
         if (!$result) {
             $message = sprintf(
-                esc_html__('Geen bestand gevonden. Controleer naam (%1$s-%2$d.{ext}), 1-based index, extensie, rechten of stel tijdelijk RMH_IMG_CACHE_BUSTER in.', 'printcom-order-tracker'),
+                esc_html__('Geen bestand gevonden. Controleer naam (%1$s-%2$d.{ext}), 1-based index, extensie, rechten of verhoog tijdelijk de cache-buster (optie rmh_img_cache_buster, admin-knop of RMH_IMG_CACHE_BUSTER).', 'printcom-order-tracker'),
                 $invoice,
                 $line
             );

--- a/inc/helpers-productimg.php
+++ b/inc/helpers-productimg.php
@@ -23,18 +23,73 @@ if (!function_exists('rmh_productimg_normalize_path')) {
 
 if (!function_exists('rmh_productimg_root_url')) {
     function rmh_productimg_root_url(): string {
-        $candidates = [home_url(), site_url()];
-        foreach ($candidates as $candidate) {
-            $parts = wp_parse_url($candidate);
-            if (!is_array($parts) || empty($parts['host'])) {
-                continue;
-            }
-            $scheme = $parts['scheme'] ?? (is_ssl() ? 'https' : 'http');
-            $port   = isset($parts['port']) ? ':' . $parts['port'] : '';
-            return trailingslashit($scheme . '://' . $parts['host'] . $port);
+        if (function_exists('home_url')) {
+            return trailingslashit(home_url());
         }
 
-        return trailingslashit(home_url());
+        if (function_exists('site_url')) {
+            return trailingslashit(site_url());
+        }
+
+        return '/';
+    }
+}
+
+if (!function_exists('rmh_productimg_get_cache_buster_option')) {
+    /**
+     * Retrieve the cache-buster option used for product image caching.
+     */
+    function rmh_productimg_get_cache_buster_option(): string {
+        if (!function_exists('get_option')) {
+            return '';
+        }
+
+        $value = get_option('rmh_img_cache_buster', '');
+        return is_string($value) ? $value : '';
+    }
+}
+
+if (!function_exists('rmh_productimg_get_cache_salt')) {
+    /**
+     * Combine the cache-buster sources (option and optional constant) into a salt string.
+     */
+    function rmh_productimg_get_cache_salt(): string {
+        $parts = [];
+
+        $option_value = rmh_productimg_get_cache_buster_option();
+        if ($option_value !== '') {
+            $parts[] = $option_value;
+        }
+
+        if (defined('RMH_IMG_CACHE_BUSTER') && RMH_IMG_CACHE_BUSTER !== '') {
+            $parts[] = (string) RMH_IMG_CACHE_BUSTER;
+        }
+
+        return implode('|', $parts);
+    }
+}
+
+if (!function_exists('rmh_productimg_set_last_debug')) {
+    /**
+     * Store debug context for the most recent product image lookup.
+     *
+     * @param array<string,mixed> $context Debug information to persist for later inspection.
+     */
+    function rmh_productimg_set_last_debug(array $context): void {
+        $context['timestamp'] = microtime(true);
+        $GLOBALS['rmh_productimg_last_debug'] = $context;
+    }
+}
+
+if (!function_exists('rmh_productimg_get_last_debug')) {
+    /**
+     * Retrieve the debug context of the most recent product image lookup.
+     *
+     * @return array<string,mixed>
+     */
+    function rmh_productimg_get_last_debug(): array {
+        $debug = $GLOBALS['rmh_productimg_last_debug'] ?? [];
+        return is_array($debug) ? $debug : [];
     }
 }
 
@@ -47,6 +102,7 @@ if (!function_exists('rmh_productimg_get_default_bases')) {
             $bases[$path] = [
                 'path'     => $path,
                 'url_base' => trailingslashit(home_url()) . 'productimg/',
+                'source'   => 'ABSPATH',
             ];
         }
 
@@ -56,7 +112,8 @@ if (!function_exists('rmh_productimg_get_default_bases')) {
                 $path = rmh_productimg_normalize_path($doc_root . '/productimg');
                 $bases[$path] = [
                     'path'     => $path,
-                    'url_base' => rmh_productimg_root_url() . 'productimg/',
+                    'url_base' => trailingslashit(home_url()) . 'productimg/',
+                    'source'   => 'DOCUMENT_ROOT',
                 ];
             }
         }
@@ -75,6 +132,7 @@ if (!function_exists('rmh_productimg_get_default_bases')) {
                 $bases[$path] = [
                     'path'     => $path,
                     'url_base' => trailingslashit(home_url()) . 'productimg/',
+                    'source'   => 'HOME_PATH',
                 ];
             }
         }
@@ -112,6 +170,7 @@ if (!function_exists('rmh_productimg_get_bases')) {
             $bases[$normalized] = [
                 'path'     => $normalized,
                 'url_base' => trailingslashit(home_url()) . 'productimg/',
+                'source'   => 'FILTER',
             ];
         }
 
@@ -184,7 +243,7 @@ if (!defined('RMH_IMG_CACHE_TTL_MISS')) {
 
 if (!function_exists('rmh_productimg_cache_key')) {
     function rmh_productimg_cache_key(string $invoice, int $lineIndex): string {
-        $salt = defined('RMH_IMG_CACHE_BUSTER') ? RMH_IMG_CACHE_BUSTER : '';
+        $salt = rmh_productimg_get_cache_salt();
         $key  = strtolower($invoice) . '|' . $lineIndex . '|' . $salt;
         return 'rmh_prodimg_' . md5($key);
     }
@@ -200,14 +259,32 @@ if (!function_exists('rmh_resolve_orderline_image')) {
      * @return array|null Result data (`url`, `path`, optionally `width`, `height`, `srcset`, `sizes`) or null when missing.
      */
     function rmh_resolve_orderline_image($invoiceNumber, $lineIndex): ?array {
-        $invoice = rmh_productimg_normalize_invoice($invoiceNumber);
-        $line    = (int) $lineIndex;
+        $raw_invoice = is_string($invoiceNumber) ? $invoiceNumber : '';
+        $invoice     = rmh_productimg_normalize_invoice($invoiceNumber);
+        $line        = (int) $lineIndex;
 
         if ($invoice === '' || $line < 1) {
+            rmh_productimg_set_last_debug([
+                'invoice'     => $invoice,
+                'raw_invoice' => $raw_invoice,
+                'line_index'  => $line,
+                'found'       => false,
+                'bases'       => [],
+                'hit'         => null,
+                'cache'       => [
+                    'key'        => null,
+                    'salt'       => rmh_productimg_get_cache_salt(),
+                    'from_cache' => false,
+                ],
+                'skipped'     => 'invalid_input',
+            ]);
+
             return null;
         }
 
-        return rmh_productimg_find_image($invoice, $line);
+        return rmh_productimg_find_image($invoice, $line, [
+            'raw_invoice' => $raw_invoice,
+        ]);
     }
 }
 
@@ -228,39 +305,102 @@ if (!function_exists('rmh_productimg_collect_image_sizes')) {
 }
 
 if (!function_exists('rmh_productimg_find_image')) {
-    function rmh_productimg_find_image(string $invoice, int $lineIndex): ?array {
+    /**
+     * Locate an automatic product image based on the invoice and line index.
+     *
+     * @param array<string,mixed> $context Additional lookup context (e.g. raw invoice) for debug purposes.
+     */
+    function rmh_productimg_find_image(string $invoice, int $lineIndex, array $context = []): ?array {
+        $raw_invoice = isset($context['raw_invoice']) && is_string($context['raw_invoice']) ? $context['raw_invoice'] : $invoice;
+
+        $cache_key = rmh_productimg_cache_key($invoice, $lineIndex);
+        $cache_salt = rmh_productimg_get_cache_salt();
+
+        $debug = [
+            'invoice'      => $invoice,
+            'raw_invoice'  => $raw_invoice,
+            'line_index'   => $lineIndex,
+            'target'       => sprintf('%s-%d', $invoice, $lineIndex),
+            'found'        => false,
+            'bases'        => [],
+            'last_base'    => null,
+            'hit'          => null,
+            'cache'        => [
+                'key'        => $cache_key,
+                'salt'       => $cache_salt,
+                'from_cache' => false,
+            ],
+            'skipped'      => null,
+            'legacy_allowed' => !rmh_productimg_is_legacy_disabled(),
+        ];
+
         if ($invoice === '' || $lineIndex < 1) {
+            $debug['skipped'] = 'invalid_arguments';
+            rmh_productimg_set_last_debug($debug);
             return null;
         }
+
         if (!rmh_productimg_is_autoload_enabled()) {
+            $debug['skipped'] = 'autoload_disabled';
+            rmh_productimg_set_last_debug($debug);
             rmh_productimg_debug_log('Autoload uitgeschakeld via filter.');
             return null;
         }
 
-        $cache_key = rmh_productimg_cache_key($invoice, $lineIndex);
         $cached = get_transient($cache_key);
         if (is_array($cached)) {
-            if (!empty($cached['found'])) {
-                return $cached['data'];
+            $debug['cache']['from_cache'] = true;
+            $debug['cache']['value']      = $cached;
+
+            if (!empty($cached['found']) && !empty($cached['data']) && is_array($cached['data'])) {
+                $cached_data = $cached['data'];
+                $debug['found'] = true;
+                $debug['hit'] = [
+                    'path' => $cached_data['path'] ?? '',
+                    'url'  => $cached_data['url'] ?? '',
+                    'base' => $cached_data['debug_base'] ?? null,
+                ];
+                $debug['last_base'] = $debug['hit']['base'];
+
+                rmh_productimg_set_last_debug($debug);
+                return $cached_data;
             }
+
+            rmh_productimg_set_last_debug($debug);
             return null;
         }
 
         $bases = rmh_productimg_get_bases();
         $extensions = rmh_productimg_get_extensions();
-        $target = sprintf('%s-%d', $invoice, $lineIndex);
+        $target = $debug['target'];
 
         foreach ($bases as $base) {
             $base_path = $base['path'];
             $url_base  = $base['url_base'];
+            $base_debug = [
+                'path'       => $base_path,
+                'url_base'   => $url_base,
+                'source'     => $base['source'] ?? '',
+                'candidates' => [],
+            ];
 
             foreach ($extensions as $ext) {
                 $candidates = array_unique([$ext, strtoupper($ext), ucfirst($ext)]);
                 foreach ($candidates as $candidate_ext) {
                     $filename = $target . '.' . $candidate_ext;
                     $absolute = $base_path . $filename;
+                    $exists   = is_readable($absolute) && is_file($absolute);
+
+                    $base_debug['candidates'][] = [
+                        'path'      => $absolute,
+                        'extension' => $candidate_ext,
+                        'exists'    => $exists,
+                        'variant'   => '',
+                        'hit'       => $exists,
+                    ];
+
                     rmh_productimg_debug_log('Probeer ' . $absolute);
-                    if (!is_readable($absolute) || !is_file($absolute)) {
+                    if (!$exists) {
                         continue;
                     }
 
@@ -277,11 +417,22 @@ if (!function_exists('rmh_productimg_find_image')) {
                     $variant_suffixes = ['@2x', '-large'];
                     foreach ($variant_suffixes as $suffix) {
                         $variant_filename = $target . $suffix . '.' . $candidate_ext;
-                        $variant_path = $base_path . $variant_filename;
+                        $variant_path     = $base_path . $variant_filename;
+                        $variant_exists   = is_readable($variant_path) && is_file($variant_path);
+
+                        $base_debug['candidates'][] = [
+                            'path'      => $variant_path,
+                            'extension' => $candidate_ext,
+                            'exists'    => $variant_exists,
+                            'variant'   => $suffix,
+                            'hit'       => $variant_exists,
+                        ];
+
                         rmh_productimg_debug_log('Zoek variant ' . $variant_path);
-                        if (!is_readable($variant_path) || !is_file($variant_path)) {
+                        if (!$variant_exists) {
                             continue;
                         }
+
                         $variant_info = rmh_productimg_collect_image_sizes($variant_path);
                         $variants[] = [
                             'url'    => $url_base . $variant_filename,
@@ -304,10 +455,15 @@ if (!function_exists('rmh_productimg_find_image')) {
                     }
 
                     $result = [
-                        'url'    => $variants[0]['url'],
-                        'path'   => $variants[0]['path'],
-                        'width'  => $variants[0]['width'] ?? null,
-                        'height' => $variants[0]['height'] ?? null,
+                        'url'        => $variants[0]['url'],
+                        'path'       => $variants[0]['path'],
+                        'width'      => $variants[0]['width'] ?? null,
+                        'height'     => $variants[0]['height'] ?? null,
+                        'debug_base' => [
+                            'path'     => $base_path,
+                            'url_base' => $url_base,
+                            'source'   => $base['source'] ?? '',
+                        ],
                     ];
 
                     if (count($variants) > 1) {
@@ -322,13 +478,35 @@ if (!function_exists('rmh_productimg_find_image')) {
                     set_transient($cache_key, ['found' => true, 'data' => $result], RMH_IMG_CACHE_TTL_HIT);
                     rmh_productimg_debug_log('Gevonden: ' . $absolute);
 
+                    $debug['bases'][] = $base_debug;
+                    $debug['found'] = true;
+                    $debug['hit'] = [
+                        'path' => $result['path'],
+                        'url'  => $result['url'],
+                        'base' => $result['debug_base'],
+                    ];
+                    $debug['last_base'] = $result['debug_base'];
+                    $debug['cache']['stored'] = 'hit';
+
+                    rmh_productimg_set_last_debug($debug);
+
                     return $result;
                 }
             }
+
+            $debug['bases'][] = $base_debug;
+            $debug['last_base'] = [
+                'path'     => $base_path,
+                'url_base' => $url_base,
+                'source'   => $base['source'] ?? '',
+            ];
         }
 
         set_transient($cache_key, ['found' => false], RMH_IMG_CACHE_TTL_MISS);
         rmh_productimg_debug_log('Geen afbeelding gevonden voor ' . $target);
+
+        $debug['cache']['stored'] = 'miss';
+        rmh_productimg_set_last_debug($debug);
 
         return null;
     }
@@ -336,8 +514,8 @@ if (!function_exists('rmh_productimg_find_image')) {
 
 if (!function_exists('rmh_render_orderline_image')) {
     function rmh_render_orderline_image($invoiceNumber, $lineIndex, array $args = []): string {
-        $invoice = rmh_productimg_normalize_invoice($invoiceNumber);
-        $line    = (int) $lineIndex;
+        $normalized_invoice = rmh_productimg_normalize_invoice($invoiceNumber);
+        $line               = (int) $lineIndex;
 
         $defaults = [
             'legacy_html'      => '',
@@ -345,16 +523,23 @@ if (!function_exists('rmh_render_orderline_image')) {
         ];
         $args = array_merge($defaults, $args);
 
-        $image = null;
-        if ($invoice !== '' && $line >= 1) {
-            $image = rmh_resolve_orderline_image($invoice, $line);
+        $image = rmh_resolve_orderline_image($invoiceNumber, $line);
+
+        $legacy_disabled = rmh_productimg_is_legacy_disabled();
+        $debug_data = [];
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            $debug_data = rmh_productimg_get_last_debug();
         }
 
         if ($image) {
+            if (isset($image['debug_base'])) {
+                unset($image['debug_base']);
+            }
+
             $alt = sprintf(
                 /* translators: 1: invoice number, 2: line index */
                 __('Productafbeelding factuur %1$s – regel %2$d', 'printcom-order-tracker'),
-                $invoice,
+                $normalized_invoice,
                 $line
             );
             $attributes = [
@@ -392,14 +577,65 @@ if (!function_exists('rmh_render_orderline_image')) {
                 $parts[] = sprintf('%s="%s"', $key, $value);
             }
             $img_html = '<img ' . implode(' ', $parts) . ' />';
-        } elseif (!rmh_productimg_is_legacy_disabled() && $args['legacy_html'] !== '') {
+        } elseif (!$legacy_disabled && $args['legacy_html'] !== '') {
             $img_html = $args['legacy_html'];
         } else {
             $img_html = $args['placeholder_html'];
         }
 
         $figure = sprintf('<figure class="rmh-orderline-image">%s</figure>', $img_html);
+        $figure = apply_filters('rmh_productimg_render_html', $figure, $normalized_invoice, $line, $args);
 
-        return apply_filters('rmh_productimg_render_html', $figure, $invoice, $line, $args);
+        $debug_comment = '';
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            $comment_parts = [
+                'invoice=' . ($normalized_invoice !== '' ? $normalized_invoice : 'n/a'),
+                'line=' . $line,
+                'found=' . ($image ? 'yes' : 'no'),
+            ];
+
+            $matches_lookup = !empty($debug_data)
+                && ($debug_data['invoice'] ?? null) === $normalized_invoice
+                && (int) ($debug_data['line_index'] ?? 0) === $line;
+
+            if ($matches_lookup) {
+                $base_source = $debug_data['hit']['base']['source'] ?? $debug_data['last_base']['source'] ?? '';
+                if ($base_source !== '') {
+                    $comment_parts[] = 'base=' . $base_source;
+                }
+
+                $cache_state = '';
+                if (!empty($debug_data['cache']['from_cache'])) {
+                    $cache_state = 'hit';
+                } elseif (!empty($debug_data['cache']['stored'])) {
+                    $cache_state = (string) $debug_data['cache']['stored'];
+                }
+                if ($cache_state !== '') {
+                    $comment_parts[] = 'cache=' . $cache_state;
+                }
+
+                if (!$image) {
+                    if (!$legacy_disabled && $args['legacy_html'] !== '') {
+                        $comment_parts[] = 'fallback=legacy';
+                    } elseif ($args['placeholder_html'] !== '') {
+                        $comment_parts[] = 'fallback=placeholder';
+                    } else {
+                        $comment_parts[] = 'fallback=none';
+                    }
+
+                    if (!empty($debug_data['skipped'])) {
+                        $comment_parts[] = 'skipped=' . $debug_data['skipped'];
+                    }
+                }
+            }
+
+            $debug_comment = '<!-- RMH dbg ' . implode(' ', $comment_parts) . ' -->';
+        }
+
+        if ($debug_comment !== '') {
+            $figure .= $debug_comment;
+        }
+
+        return $figure;
     }
 }

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
 
- * Version:     2.4.33
+ * Version:     2.4.34
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -15,7 +15,14 @@ require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-clien
 require_once plugin_dir_path(__FILE__) . 'inc/helpers-productimg.php';
 
 if (is_admin()) {
-    require_once plugin_dir_path(__FILE__) . 'inc/admin-test-page.php';
+    $rmh_can_load_admin_tools = true;
+    if (function_exists('current_user_can')) {
+        $rmh_can_load_admin_tools = current_user_can('manage_options');
+    }
+
+    if ($rmh_can_load_admin_tools) {
+        require_once plugin_dir_path(__FILE__) . 'inc/admin-test-page.php';
+    }
 }
 
 add_action('init', function () {
@@ -37,7 +44,7 @@ if (defined('WP_CLI') && WP_CLI) {
 }
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.4.33';
+    public const PLUGIN_VERSION = '2.4.34';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
 
     const OPT_SETTINGS     = 'printcom_ot_settings';
@@ -841,7 +848,7 @@ class Printcom_Order_Tracker {
         if($items && is_array($items)){
             $html .= '<div class="rmh-ot__grid">';
             foreach($items as $index=>$it){
-                $n = $index + 1;
+                $line_index = $index + 1;
                 $inum = $it['orderItemNumber'] ?? '';
                 $qty  = isset($it['quantity']) ? (int)$it['quantity'] : null;
                 $title = $this->pretty_product_title($it);
@@ -864,7 +871,7 @@ class Printcom_Order_Tracker {
                     }
                 }
 
-                $img_html = rmh_render_orderline_image($invoice_number, $n, [
+                $img_html = rmh_render_orderline_image($invoice_number, $line_index, [
                     'legacy_html'      => $legacy_html,
                     'placeholder_html' => $this->placeholder_svg(),
                 ]);
@@ -902,7 +909,7 @@ class Printcom_Order_Tracker {
                 $html .= '<div class="rmh-ot__item">';
                 $html .=   '<div class="rmh-ot__item-header">';
                 $html .=     '<div class="rmh-ot__badge-top">'.$status_badge.'</div>';
-                $html .=     '<h2 class="rmh-ot__title">'.$n.'. '.esc_html($title).'</h2>';
+                $html .=     '<h2 class="rmh-ot__title">'.$line_index.'. '.esc_html($title).'</h2>';
                 $html .=   '</div>';
 
                 $html .=   '<div class="rmh-ot__item-grid">';

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Tokens worden automatisch vernieuwd. Ontworpen om goed samen te werken met **Div
 - Cache instelbaar (default 30 minuten)
 - Ondersteuning voor eigen afbeelding per orderpagina
 - Automatische productafbeeldingen vanuit `/productimg/` op basis van factuurnummer en regelnummers (met fallback op legacy bijlagen en placeholders)
-- Ingebouwde debugtools voor productafbeeldingen (shortcode, admin testpagina en WP-CLI commando)
+- Ingebouwde debugtools voor productafbeeldingen (shortcode, admin testpagina met cache-buster knop en WP-CLI commando)
 - Tokens worden automatisch vernieuwd
 
 ## Gebruik
@@ -44,17 +44,23 @@ Tokens worden automatisch vernieuwd. Ontworpen om goed samen te werken met **Div
   De URL van een gevonden bestand wordt altijd opgebouwd met `home_url()` zodat installaties in een submap geen ongewenste `/wp/` prefix krijgen. Je kunt extra paden toevoegen via de filter `rmh_productimg_bases`.
 - Vind je meerdere varianten, dan genereert de plugin nette HTML: `<figure class="rmh-orderline-image"><img ... /></figure>` met `loading="lazy"` en `decoding="async"`.
 - Wanneer er geen bestand wordt gevonden, valt de weergave terug op legacy bijlagen (mits ingeschakeld) en daarna op de ingebouwde placeholder.
-- Resultaten van zoekacties worden gecachet via transients. Met de optionele constanten `RMH_IMG_CACHE_TTL_HIT`, `RMH_IMG_CACHE_TTL_MISS` en `RMH_IMG_CACHE_BUSTER` kun je TTL’s aanpassen en tijdens debuggen cache busten. Extra filters: `rmh_productimg_exts`, `rmh_productimg_enable_autoload` en `rmh_productimg_render_html` voor geavanceerde aanpassingen.
+- Resultaten van zoekacties worden gecachet via transients. Gebruik de adminknop (of optie `rmh_img_cache_buster`/constante `RMH_IMG_CACHE_BUSTER`) om caches direct te vernieuwen. TTL’s zijn instelbaar via `RMH_IMG_CACHE_TTL_HIT` en `RMH_IMG_CACHE_TTL_MISS`. Extra filters: `rmh_productimg_exts`, `rmh_productimg_enable_autoload` en `rmh_productimg_render_html` voor geavanceerde aanpassingen.
 
 ### Debuggen productafbeeldingen
 - **Shortcode**: `[rmh_test_image invoice="RMH-0021" index="1"]` toont het pad, de URL en de afbeelding (alleen beschikbaar voor beheerders tenzij je de filter `rmh_enable_debug_shortcodes` activeert).
-- **Admin testpagina**: via **Instellingen → RMH Productimg Test** kun je factuurnummer + regelindex invoeren en direct het resultaat zien.
+- **Admin testpagina**: via **Instellingen → RMH Productimg Test** krijg je per lookup de gekozen basis, alle kandidaten, hit/miss, cache-info én een cache-buster knop.
 - **WP-CLI**: `wp rmh img-test RMH-0021 1` controleert dezelfde resolver en geeft pad + URL terug. Bij een miss krijg je een waarschuwing en exitcode 1.
-- Nieuwe bestanden direct testen? Zet tijdelijk `define('RMH_IMG_CACHE_BUSTER', 'v2');` in `wp-config.php` zodat alle caches worden vernieuwd.
+- Nieuwe bestanden direct testen? Gebruik de cache-buster knop, wijzig de optie `rmh_img_cache_buster` of zet tijdelijk `define('RMH_IMG_CACHE_BUSTER', 'v2');` in `wp-config.php` zodat alle caches worden vernieuwd.
+- Bij `WP_DEBUG` verschijnt per orderregel een HTML-comment `<!-- RMH dbg … -->` met de gebruikte basis, cache-status en fallback.
+
+### Diagnose & cache
+- De admin testpagina toont nu per lookup de geselecteerde basis, alle filekandidaten, cache-actie (hit/miss) en een voorbeeldpad/URL voor DOCUMENT_ROOT (bijv. `/var/www/.../productimg/` → `https://rikkermediahub.com/productimg/`).
+- Met de knop **Cache buster verhogen** wijzig je direct de optie `rmh_img_cache_buster`; de resolver combineert die waarde met een eventuele constante `RMH_IMG_CACHE_BUSTER` voor de cache-salt.
+- TTL’s voor hits en misses blijven instelbaar via `RMH_IMG_CACHE_TTL_HIT` en `RMH_IMG_CACHE_TTL_MISS` (defaults respectievelijk 15 en 5 minuten).
 
 ### Configuratie
 - `RMH_DISABLE_LEGACY_IMAGES` – schakelt legacy bijlagen als fallback uit.
-- `RMH_IMG_CACHE_BUSTER` – voeg een willekeurige string toe om caches direct ongeldig te maken.
+- `rmh_img_cache_buster` (option) / `RMH_IMG_CACHE_BUSTER` (constante) – voeg een willekeurige string toe om caches direct ongeldig te maken.
 - `RMH_IMG_CACHE_TTL_HIT` / `RMH_IMG_CACHE_TTL_MISS` – pas de TTL (in seconden) voor respectievelijk hits en misses aan.
 
 ### Cache & tokens


### PR DESCRIPTION
## Summary
- guard the admin test page load, enforce 1-based orderline rendering on the order page, and bump the plugin to 2.4.34
- update the automatic resolver to prefer home_url()-based paths, salt caches with the rmh_img_cache_buster option, and surface WP_DEBUG HTML diagnostics
- expand the admin test tool with cache-buster controls, TTL info, detailed candidate reporting, and document the new workflow in README/CHANGELOG

## Testing
- php -l inc/helpers-productimg.php
- php -l inc/admin-test-page.php
- php -l inc/cli-commands.php
- php -l inc/debug-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d152a1f73c832ca5b81fd8b092066f