### PR TITLE
Refine multi-shipment rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.1
+- Toon meerdere afleveradressen per orderregel met aantallen en leverdatum op één regel.
+- Label de adressectie automatisch enkelvoud of meervoud en behoud compatibiliteit met postcode-lookup.
+- Versienummer verhoogd naar 2.5.1.
+
 ## 2.5.0
 - Hardcode Print.com API en login endpoints in de plugin; instellingen voor base/auth/grant verwijderd.
 - Authenticatie gebruikt enkel gebruikersnaam en wachtwoord en verwijderde Client ID/Secret opties.


### PR DESCRIPTION
## Summary
- render each shipment address per orderregel op één regel met aantallen en leverdatum en toon een enkelvoud/meervoud heading
- behoud de postcode-lookup door alle afleveradressen te blijven normaliseren en verhoog de plug-inversie naar 2.5.1
- documenteer de wijziging in het changelog

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68d669629244832ca8178f353bb1d428