### PR TITLE
Restore address block layout for shipment list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.5.2
+- Herstelde de oorspronkelijke adresopmaak per orderregel en dupliceer deze wanneer meerdere zendingen aanwezig zijn.
+- Toon aantallen en leverdatums onder elk adresblok zonder extra labels voor de afleveradressen.
+- Versienummer verhoogd naar 2.5.2.
+
+## 2.5.1
+- Toon meerdere afleveradressen per orderregel met aantallen en leverdatum op één regel.
+- Label de adressectie automatisch enkelvoud of meervoud en behoud compatibiliteit met postcode-lookup.
+- Versienummer verhoogd naar 2.5.1.
+
 ## 2.5.0
 - Hardcode Print.com API en login endpoints in de plugin; instellingen voor base/auth/grant verwijderd.
 - Authenticatie gebruikt enkel gebruikersnaam en wachtwoord en verwijderde Client ID/Secret opties.

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
 
- * Version:     2.5.0
+ * Version:     2.5.2
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.5.0';
+    public const PLUGIN_VERSION = '2.5.2';
     public const API_BASE_URL   = 'https://api.print.com/';
     public const AUTH_URL       = 'https://api.print.com/login';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
@@ -832,7 +832,7 @@ class Printcom_Order_Tracker {
                 $eig = $specs['eigenschappen']; $extra = $specs['extras'];
 
                 // Bezorgadres (per item!)
-                $addr = $this->extract_item_address($it);
+                $item_shipments = $this->extract_item_shipments_details($it);
 
                 // Leverdata + methode (per item!)
                 $dw = $this->extract_item_delivery_window($it);
@@ -882,21 +882,68 @@ class Printcom_Order_Tracker {
                 // kolom 3: adres + datum/methode + T&T knop
                 $html .=   '<div class="rmh-ot__delivery">';
                 // Adres
-                $html .=     '<div class="rmh-ot__panel">';
-                $html .=       '<h4>Bezorgadres(sen)</h4>';
-                if ($addr) {
-                    $fn      = trim(($addr['firstName'] ?? '').' '.($addr['lastName'] ?? ''));
-                    $street  = trim(                ($addr['fullstreet'] ?? '').' '.($addr['houseNumber'] ?? ''));
-                    $city    = trim(($addr['postcode'] ?? '').' '.($addr['city'] ?? ''));
-                    $country = $addr['country'] ?? '';
+                $multiple_shipments = count($item_shipments) > 1;
+                $address_heading   = $multiple_shipments ? 'Bezorgadressen' : 'Bezorgadres';
 
-                    $html .= '<p>';
-                    if ($fn)      $html .= '<strong>'.esc_html($fn).'</strong><br>';
-                    if ($street)  $html .= esc_html($street).'<br>';
-                    if ($city)    $html .= esc_html($city).'<br>';
-                    if ($country) $html .= esc_html($country);
+                $html .=     '<div class="rmh-ot__panel">';
+                $html .=       '<h4>' . esc_html($address_heading) . '</h4>';
+                $shipments_rendered = 0;
+
+                foreach ($item_shipments as $shipment_info) {
+                    $address_lines = [];
+                    if (!empty($shipment_info['address']) && is_array($shipment_info['address'])) {
+                        $address_lines = array_filter(array_map('trim', $this->build_address_lines($shipment_info['address'])));
+                    }
+
+                    $copies_text   = $this->format_shipment_copies($shipment_info['copies'] ?? null);
+                    $delivery_text = $this->format_shipment_delivery_text($shipment_info);
+
+                    $meta_parts = [];
+                    if ($copies_text) {
+                        $meta_parts[] = $copies_text;
+                    }
+                    if ($delivery_text) {
+                        $meta_parts[] = sprintf('Leverdatum: %s', $delivery_text);
+                    }
+
+                    if (!$address_lines && !$meta_parts) {
+                        continue;
+                    }
+
+                    $shipments_rendered++;
+
+                    $html .= '<div class="rmh-ot__shipment">';
+                    $html .= '<p class="rmh-ot__shipment-address">';
+
+                    if ($address_lines) {
+                        $address_html = '';
+                        foreach (array_values($address_lines) as $line_idx => $line) {
+                            $line_html = esc_html($line);
+                            if ($line_idx === 0) {
+                                $line_html = '<strong>' . $line_html . '</strong>';
+                            }
+
+                            if ($line_idx > 0) {
+                                $address_html .= '<br>';
+                            }
+                            $address_html .= $line_html;
+                        }
+
+                        $html .= $address_html;
+                        if ($meta_parts) {
+                            $html .= '<br>';
+                        }
+                    }
+
+                    if ($meta_parts) {
+                        $html .= '<small class="rmh-ot__shipment-meta">' . esc_html(implode(' • ', $meta_parts)) . '</small>';
+                    }
+
                     $html .= '</p>';
-                } else {
+                    $html .= '</div>';
+                }
+
+                if ($shipments_rendered === 0) {
                     $html .= '<p><em>Nog geen adresinformatie beschikbaar.</em></p>';
                 }
                 $html .=     '</div>';
@@ -2073,9 +2120,143 @@ class Printcom_Order_Tracker {
     }
 
     private function extract_item_address(array $item): ?array {
-        foreach (($item['shipments'] ?? []) as $s) {
-            if (!empty($s['address'])) return $s['address'];
+        $shipments = $this->extract_item_shipments_details($item);
+        foreach ($shipments as $shipment) {
+            if (!empty($shipment['address']) && is_array($shipment['address'])) {
+                return $shipment['address'];
+            }
         }
+        return null;
+    }
+
+    private function extract_item_shipments_details(array $item): array {
+        $details = [];
+
+        foreach (($item['shipments'] ?? []) as $shipment) {
+            if (!is_array($shipment)) {
+                continue;
+            }
+
+            $address = [];
+            if (!empty($shipment['address']) && is_array($shipment['address'])) {
+                $address = $shipment['address'];
+            }
+
+            $copies = null;
+            if (isset($shipment['copies'])) {
+                $copies = is_numeric($shipment['copies']) ? (int) $shipment['copies'] : null;
+                if (is_int($copies) && $copies < 0) {
+                    $copies = null;
+                }
+            }
+
+            $delivery = null;
+            if (!empty($shipment['deliveryDate'])) {
+                $delivery = $this->fmt_date_ymdh((string) $shipment['deliveryDate']);
+            }
+
+            $latest = null;
+            if (!empty($shipment['latestDeliveryDate'])) {
+                $latest = $this->fmt_date_ymdh((string) $shipment['latestDeliveryDate']);
+            }
+
+            $details[] = [
+                'address'             => $address,
+                'copies'              => $copies,
+                'deliveryDate'        => $delivery,
+                'latestDeliveryDate'  => $latest,
+                'rawDeliveryDate'     => isset($shipment['deliveryDate']) ? (string) $shipment['deliveryDate'] : null,
+                'rawLatestDeliveryDate' => isset($shipment['latestDeliveryDate']) ? (string) $shipment['latestDeliveryDate'] : null,
+            ];
+        }
+
+        return $details;
+    }
+
+    private function build_address_lines(array $address): array {
+        $lines = [];
+
+        $full_name = trim(trim((string) ($address['firstName'] ?? '')) . ' ' . trim((string) ($address['lastName'] ?? '')));
+        if ($full_name !== '') {
+            $lines[] = $full_name;
+        }
+
+        $street_base = '';
+        if (!empty($address['fullstreet'])) {
+            $street_base = (string) $address['fullstreet'];
+        } elseif (!empty($address['street'])) {
+            $street_base = (string) $address['street'];
+        }
+
+        $house_number = trim(trim((string) ($address['houseNumber'] ?? '')) . ' ' . trim((string) ($address['houseNumberAddition'] ?? '')));
+        $house_number = preg_replace('/\s+/', ' ', $house_number);
+        if (!is_string($house_number)) {
+            $house_number = '';
+        }
+
+        if ($street_base !== '') {
+            $street_line = trim($street_base . ($house_number !== '' ? ' ' . $house_number : ''));
+            if ($street_line !== '') {
+                $lines[] = $street_line;
+            }
+        } elseif ($house_number !== '') {
+            $lines[] = $house_number;
+        }
+
+        $postcode = strtoupper(trim((string) ($address['postcode'] ?? '')));
+        $city = trim((string) ($address['city'] ?? ''));
+        $city_line = trim($postcode . ' ' . $city);
+        if ($city_line !== '') {
+            $lines[] = $city_line;
+        }
+
+        $country = trim((string) ($address['country'] ?? ''));
+        if ($country !== '') {
+            $lines[] = $country;
+        }
+
+        return $lines;
+    }
+
+    private function format_shipment_copies($copies): ?string {
+        if (!is_int($copies) || $copies < 0) {
+            return null;
+        }
+
+        $label = $copies === 1 ? 'stuk' : 'stuks';
+        return sprintf('%s %s', number_format_i18n($copies), $label);
+    }
+
+    private function format_shipment_delivery_text(array $shipment): ?string {
+        foreach (['deliveryDate', 'latestDeliveryDate'] as $key) {
+            if (!empty($shipment[$key]) && $shipment[$key] instanceof DateTime) {
+                return $shipment[$key]->format('d-m-Y');
+            }
+        }
+
+        foreach (['rawDeliveryDate', 'rawLatestDeliveryDate'] as $raw_key) {
+            if (empty($shipment[$raw_key]) || !is_string($shipment[$raw_key])) {
+                continue;
+            }
+
+            $raw = trim($shipment[$raw_key]);
+            if ($raw === '') {
+                continue;
+            }
+
+            if (preg_match('/^(\d{4}-\d{2}-\d{2})/', $raw, $m)) {
+                try {
+                    $dt = new DateTime($m[1]);
+                    return $dt->format('d-m-Y');
+                } catch (\Throwable $e) {
+                    // Val terug op de ruwe waarde hieronder
+                }
+                return $m[1];
+            }
+
+            return $raw;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
## Summary
- restore the original address block layout per item while rendering one block per shipment with quantities and delivery dates
- remove the per-address labels and show shipment metadata beneath the address so duplicate addresses keep the original styling
- bump the plugin version to 2.5.2 and document the change in the changelog

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68d669629244832ca8178f353bb1d428