### PR TITLE
Adjust shipment meta display for single and multi-address orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.3
+- Verberg het aantal exemplaren en leverdatum onder het bezorgadres wanneer een product maar één verzendadres heeft.
+- Toon bij meerdere adressen alleen het aantal exemplaren en laat de leverdatum achterwege omdat die elders zichtbaar is.
+- Versienummer verhoogd naar 2.5.3.
+
 ## 2.5.2
 - Herstelde de oorspronkelijke adresopmaak per orderregel en dupliceer deze wanneer meerdere zendingen aanwezig zijn.
 - Toon aantallen en leverdatums onder elk adresblok zonder extra labels voor de afleveradressen.

--- a/printcom-order-tracker.php
+++ b/printcom-order-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name: Print.com Order Tracker (Track & Trace Pagina's)
  * Description: Maakt per ordernummer automatisch een track & trace pagina aan en toont live orderstatus, items en verzendinformatie via de Print.com API. Tokens worden automatisch vernieuwd. Divi-vriendelijk.
 
- * Version:     2.5.2
+ * Version:     2.5.3
  * Author:      RikkerMediaHub
  * License:     GNU GPLv2
  * Text Domain: printcom-order-tracker
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) exit;
 require_once plugin_dir_path(__FILE__) . 'includes/class-rmh-invoice-ninja-client.php';
 
 class Printcom_Order_Tracker {
-    public const PLUGIN_VERSION = '2.5.2';
+    public const PLUGIN_VERSION = '2.5.3';
     public const API_BASE_URL   = 'https://api.print.com/';
     public const AUTH_URL       = 'https://api.print.com/login';
     public const USER_AGENT     = 'RMH-Printcom-Tracker/1.6.1 (+WordPress)';
@@ -895,15 +895,11 @@ class Printcom_Order_Tracker {
                         $address_lines = array_filter(array_map('trim', $this->build_address_lines($shipment_info['address'])));
                     }
 
-                    $copies_text   = $this->format_shipment_copies($shipment_info['copies'] ?? null);
-                    $delivery_text = $this->format_shipment_delivery_text($shipment_info);
+                    $copies_text = $this->format_shipment_copies($shipment_info['copies'] ?? null);
 
                     $meta_parts = [];
-                    if ($copies_text) {
+                    if ($multiple_shipments && $copies_text) {
                         $meta_parts[] = $copies_text;
-                    }
-                    if ($delivery_text) {
-                        $meta_parts[] = sprintf('Leverdatum: %s', $delivery_text);
                     }
 
                     if (!$address_lines && !$meta_parts) {


### PR DESCRIPTION
## Summary
- hide shipment meta beneath single-address products so the panel stays concise
- keep copy counts for multi-address products but drop the per-address delivery date that is shown elsewhere
- bump the plugin version to 2.5.3 and document the change in the changelog

## Testing
- php -l printcom-order-tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68d680f52c84832c993597363987fccc